### PR TITLE
[skip ci] Grammar Fix 2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ version [on our GitHub](https://github.com/LBPUnion/rpcs3).*
 Start by getting a copy of LittleBigPlanet 1/2 installed. (Check the LittleBigPlanet 1 section, since you'll need to do
 extra steps for your game to not crash upon entering pod computer). 
 
-The game can be a digital copy (NPUA80472/NPUA80662) or a disc copy (
-BCUS98148/BCUS98245).
+The game can be a digital copy (NPUA80472/NPUA80662) or a disc copy (BCUS98148/BCUS98245).
 
 Next, download [UnionPatcher](https://github.com/LBPUnion/UnionPatcher/). Binaries can be found by reading the `README.md`
 file.


### PR DESCRIPTION
Basically there was an excess space before BCUS98148 in the setup guide, and yes I know it looks like nothing but it fixes the grammar.