### PR TITLE
Fix race conditoon in tests

### DIFF
--- a/ProjectLighthouse.Tests.GameApiTests/AuthenticationTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/AuthenticationTests.cs
@@ -46,7 +46,7 @@ public class AuthenticationTests : LighthouseServerTest
     {
         LoginResult loginResult = await this.Authenticate();
 
-        HttpResponseMessage response = await this.AuthenticatedRequest("/LITTLEBIGPLANETPS3_XML/enterLevel/1", loginResult.AuthTicket);
+        HttpResponseMessage response = await this.AuthenticatedRequest("/LITTLEBIGPLANETPS3_XML/enterLevel/420", loginResult.AuthTicket);
         string responseContent = await response.Content.ReadAsStringAsync();
 
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);


### PR DESCRIPTION
This fix was in my last PR but it got yeeted. Currently, the slot upload test and the CanUseToken test cause problems for each other since they both use slot id 1. By using a different slot id that is never valid it prevents the enterLevel controller from passing the existence check and trying to save changes.