### PR TITLE
Improve user profile picture loading speeds

### DIFF
--- a/ProjectLighthouse/Controllers/GameApi/UserController.cs
+++ b/ProjectLighthouse/Controllers/GameApi/UserController.cs
@@ -41,7 +41,7 @@ public class UserController : ControllerBase
                 u.Username,
                 u.IconHash,
             }).FirstOrDefaultAsync();
-        if (partialUser == null) return "";
+        if (partialUser == null) return null;
         string user = LbpSerializer.TaggedStringElement("npHandle", partialUser.Username, "icon", partialUser.IconHash);
         return LbpSerializer.TaggedStringElement("user", user, "type", "user");
     }


### PR DESCRIPTION
The /users endpoint in-game actually only cares about the user's icon so there is no point in serializing their entire profile. I also used projection so only the icon and username column are fetched which in the worst-case sped up performance by about half compared to just fetching the user normally.

From my testing, the current implementation could take up to half a second for just 3 profiles that weren't fully filled out so I imagine this could take a long time for larger queries. The new method takes just 100ms in the same worst-case scenario. In the average scenario, the speedup is about 8x going from 80ms on average to less than 10ms on average.

The effects of this can be seen everywhere because loading levels, comments, reviews, scores, and practically anything user-related involves loading their profile picture.