### PR TITLE
Add ability to grant a user additional slots

### DIFF
--- a/ProjectLighthouse/Migrations/20220402212909_AddAdminGrantedSlotsToUser.cs
+++ b/ProjectLighthouse/Migrations/20220402212909_AddAdminGrantedSlotsToUser.cs
@@ -1,0 +1,30 @@
+﻿using LBPUnion.ProjectLighthouse;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectLighthouse.Migrations
+{
+    [DbContext(typeof(Database))]
+    [Migration("20220402212909_AddAdminGrantedSlotsToUser")]
+    public partial class AddAdminGrantedSlotsToUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AdminGrantedSlots",
+                table: "Users",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdminGrantedSlots",
+                table: "Users");
+        }
+    }
+}

--- a/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace ProjectLighthouse.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.2")
+                .HasAnnotation("ProductVersion", "6.0.3")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.AuthenticationAttempt", b =>
@@ -693,6 +693,9 @@ namespace ProjectLighthouse.Migrations
                 {
                     b.Property<int>("UserId")
                         .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<int>("AdminGrantedSlots")
                         .HasColumnType("int");
 
                     b.Property<bool>("Banned")

--- a/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml
+++ b/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml
@@ -1,0 +1,19 @@
+@page "/admin/user/{id:int}/setGrantedSlots"
+@model LBPUnion.ProjectLighthouse.Pages.Admin.AdminSetGrantedSlotsPage
+
+@{
+    Layout = "Layouts/BaseLayout";
+    Model.Title = "Set granted slots for " + Model.TargetedUser!.Username;
+}
+
+<form method="post">
+    @Html.AntiForgeryToken()
+
+    <div class="ui left action input">
+        <button type="submit" class="ui blue button">
+            <i class="pencil icon"></i>
+            <span>Set Granted Slots</span>
+        </button>
+        <input type="text" name="grantedSlotCount" placeholder="Granted Slots" value="@Model.TargetedUser.AdminGrantedSlots">
+    </div><br><br>
+</form>

--- a/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml
+++ b/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml
@@ -6,14 +6,4 @@
     Model.Title = "Set granted slots for " + Model.TargetedUser!.Username;
 }
 
-<form method="post">
-    @Html.AntiForgeryToken()
-
-    <div class="ui left action input">
-        <button type="submit" class="ui blue button">
-            <i class="pencil icon"></i>
-            <span>Set Granted Slots</span>
-        </button>
-        <input type="text" name="grantedSlotCount" placeholder="Granted Slots" value="@Model.TargetedUser.AdminGrantedSlots">
-    </div><br><br>
-</form>
+@await Html.PartialAsync("Partials/AdminSetGrantedSlotsFormPartial", Model.TargetedUser)

--- a/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml.cs
+++ b/ProjectLighthouse/Pages/Admin/AdminSetGrantedSlotsPage.cshtml.cs
@@ -1,0 +1,41 @@
+#nullable enable
+using System.Threading.Tasks;
+using LBPUnion.ProjectLighthouse.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Pages.Admin;
+
+public class AdminSetGrantedSlotsPage : BaseLayout
+{
+    public AdminSetGrantedSlotsPage(Database database) : base(database)
+    {}
+
+    public User? TargetedUser;
+
+    public async Task<IActionResult> OnGet([FromRoute] int id)
+    {
+        User? user = this.Database.UserFromWebRequest(this.Request);
+        if (user == null || !user.IsAdmin) return this.NotFound();
+
+        this.TargetedUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == id);
+        if (this.TargetedUser == null) return this.NotFound();
+
+        return this.Page();
+    }
+
+    public async Task<IActionResult> OnPost([FromRoute] int id, int grantedSlotCount)
+    {
+        User? user = this.Database.UserFromWebRequest(this.Request);
+        if (user == null || !user.IsAdmin) return this.NotFound();
+
+        this.TargetedUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == id);
+        if (this.TargetedUser == null) return this.NotFound();
+
+        this.TargetedUser.AdminGrantedSlots = grantedSlotCount;
+
+        await this.Database.SaveChangesAsync();
+        return this.Redirect($"/user/{this.TargetedUser.UserId}");
+    }
+}

--- a/ProjectLighthouse/Pages/Partials/AdminSetGrantedSlotsFormPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/AdminSetGrantedSlotsFormPartial.cshtml
@@ -1,0 +1,12 @@
+@model LBPUnion.ProjectLighthouse.Types.User
+
+<form method="post" action="/admin/user/@Model.UserId/setGrantedSlots">
+    @Html.AntiForgeryToken()
+    <div class="ui left action input">
+        <button type="submit" class="ui blue button">
+            <i class="pencil icon"></i>
+            <span>Set Granted Slots</span>
+        </button>
+        <input type="text" name="grantedSlotCount" placeholder="Granted Slots" value="@Model.AdminGrantedSlots">
+    </div>
+</form>

--- a/ProjectLighthouse/Pages/UserPage.cshtml
+++ b/ProjectLighthouse/Pages/UserPage.cshtml
@@ -73,12 +73,7 @@
             </a>
         }
         @if (Model.User != null && Model.User.IsAdmin && !Model.ProfileUser.Banned)
-        {
-            <a class="ui red button" href="/admin/user/@Model.ProfileUser.UserId/ban">
-                <i class="ban icon"></i>
-                <span>Ban User</span>
-            </a>
-        }
+        {}
     </div>
     <div class="eight wide column">
         <div class="ui blue segment">
@@ -119,3 +114,31 @@
 }
 
 @await Html.PartialAsync("Partials/CommentsPartial")
+
+@if (Model.User != null && Model.User.IsAdmin)
+{
+    <div class="ui yellow segment">
+        <h2>Admin Options</h2>
+
+        @if (!Model.ProfileUser.Banned)
+        {
+            <a class="ui red button" href="/admin/user/@Model.ProfileUser.UserId/ban">
+                <i class="ban icon"></i>
+                <span>Ban User</span>
+            </a>
+        <br><br>
+        }
+
+        <form method="post" action="/admin/user/@Model.ProfileUser.UserId/setGrantedSlots">
+            @Html.AntiForgeryToken()
+            <div class="ui left action input">
+                <button type="submit" class="ui blue button">
+                    <i class="pencil icon"></i>
+                    <span>Set Granted Slots</span>
+                </button>
+                <input type="text" name="grantedSlotCount" placeholder="Granted Slots" value="@Model.ProfileUser.AdminGrantedSlots">
+            </div>
+        </form>
+    </div>
+        }
+    

--- a/ProjectLighthouse/Pages/UserPage.cshtml
+++ b/ProjectLighthouse/Pages/UserPage.cshtml
@@ -72,7 +72,6 @@
                 <span>Reset Password</span>
             </a>
         }
-        @if (Model.User != null && Model.User.IsAdmin && !Model.ProfileUser.Banned)
         {}
     </div>
     <div class="eight wide column">

--- a/ProjectLighthouse/Pages/UserPage.cshtml
+++ b/ProjectLighthouse/Pages/UserPage.cshtml
@@ -72,7 +72,6 @@
                 <span>Reset Password</span>
             </a>
         }
-        {}
     </div>
     <div class="eight wide column">
         <div class="ui blue segment">

--- a/ProjectLighthouse/Pages/UserPage.cshtml
+++ b/ProjectLighthouse/Pages/UserPage.cshtml
@@ -125,19 +125,10 @@
                 <i class="ban icon"></i>
                 <span>Ban User</span>
             </a>
+        
         <br><br>
         }
 
-        <form method="post" action="/admin/user/@Model.ProfileUser.UserId/setGrantedSlots">
-            @Html.AntiForgeryToken()
-            <div class="ui left action input">
-                <button type="submit" class="ui blue button">
-                    <i class="pencil icon"></i>
-                    <span>Set Granted Slots</span>
-                </button>
-                <input type="text" name="grantedSlotCount" placeholder="Granted Slots" value="@Model.ProfileUser.AdminGrantedSlots">
-            </div>
-        </form>
+        @await Html.PartialAsync("Partials/AdminSetGrantedSlotsFormPartial", Model.ProfileUser)
     </div>
         }
-    

--- a/ProjectLighthouse/Types/User.cs
+++ b/ProjectLighthouse/Types/User.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json.Serialization;
+using System.Xml.Serialization;
 using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Profiles;
 using LBPUnion.ProjectLighthouse.Types.Settings;
@@ -199,11 +200,19 @@ public class User
     }
     #nullable disable
 
+    [JsonIgnore]
+    [XmlIgnore]
+    public int EntitledSlots => ServerSettings.Instance.EntitledSlots + this.AdminGrantedSlots;
+
     /// <summary>
     ///     The number of slots remaining on the earth
     /// </summary>
     [JsonIgnore]
-    public int FreeSlots => ServerSettings.Instance.EntitledSlots - this.UsedSlots;
+    public int FreeSlots => this.EntitledSlots - this.UsedSlots;
+
+    [JsonIgnore]
+    [XmlIgnore]
+    public int AdminGrantedSlots { get; set; }
 
     private static readonly string[] slotTypes =
     {
@@ -232,12 +241,12 @@ public class User
             slotTypesLocal = slotTypes;
         }
 
-        slots += LbpSerializer.StringElement("entitledSlots", ServerSettings.Instance.EntitledSlots);
+        slots += LbpSerializer.StringElement("entitledSlots", this.EntitledSlots);
         slots += LbpSerializer.StringElement("freeSlots", this.FreeSlots);
 
         foreach (string slotType in slotTypesLocal)
         {
-            slots += LbpSerializer.StringElement(slotType + "EntitledSlots", ServerSettings.Instance.EntitledSlots);
+            slots += LbpSerializer.StringElement(slotType + "EntitledSlots", this.EntitledSlots);
             // ReSharper disable once StringLiteralTypo
             slots += LbpSerializer.StringElement(slotType + slotType == "crossControl" ? "PurchsedSlots" : "PurchasedSlots", 0);
             slots += LbpSerializer.StringElement(slotType + "FreeSlots", this.FreeSlots);


### PR DESCRIPTION
This moves the ban user button to a new Admin Options panel at the bottom of a user page:
![image](https://user-images.githubusercontent.com/40577357/161403530-cb3901c2-044c-4784-9773-dafff7147619.png)

The value you set will be applied in addition to the instance's default slot quota, 
So, for example, if the server's slot quota was 50 and you granted 14 additional slots, the total slot quota for that user would be 64.

*Closes #232*