### PR TITLE
Add some disclaimers to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ For general questions and discussion about Project Lighthouse, please see
 the [megathread](https://www.lbpunion.com/forum/union-hall/project-lighthouse-littlebigplanet-private-servers-megathread)
 on our forum.
 
-## DISCLAIMER
+## DISCLAIMERS (Please read!)
 
+### This is not a final product.
 This is **beta software**, and thus is **not stable nor is it secure**.
 
 While Project Lighthouse is in a mostly working state, **we ask that our software not be used in a production
@@ -23,6 +24,29 @@ Simply put, **Project Lighthouse is not ready for the general public yet**.
 
 In addition, we're not responsible if someone hacks your machine and wipes your database, so make frequent backups, and
 be sure to report any vulnerabilities. Thank you in advance.
+
+### We are not obligated to provide support.
+
+Project Lighthouse is open source. However, it is licensed under the GNU Affero General Public License version 3 (
+AGPLv3)
+meaning that Project Lighthouse is provided to you as-is, with **absolutely no warranty.**
+
+Please understand that while this license gives you freedom to do pretty much anything you would want to do, including
+allowing you to run your instance,
+**this doesn't mean we are obligated to support you or your instance**. When you set up an instance of Project
+Lighthouse, you are entirely on your own.
+
+### Sony is not related nor liable.
+
+[//]: # (Referenced from https://www.lbpunion.com/post/project-lighthouse-littlebigplanet-private-servers)
+
+It is very important to stress that the LBP Union and Project Lighthouse is not affiliated with Sony Group
+Corporation *(collectively referred to as “Sony”)* and its subordinate entities and studios. We are not the official
+developers of LittleBigPlanet or it's online services. Project Lighthouse is a clean-room reimplementation of its
+server, not the official servers.
+
+By using Project Lighthouse you release Sony, as well as any employees or agents of Sony, from any and all liability,
+corporate, or personal loss caused to you or others by the use of Project Lighthouse or any features we provide.
 
 ## Building
 


### PR DESCRIPTION
The hope is that we can link to this section of the README whenever someone tries to ask for support for running an unofficial Project Lighthouse instance.

I also copypasted most of the legalties from the initial Lighthouse article and added it as a new section.