### PR TITLE
Fix slot version bug and other improvements

### DIFF
--- a/ProjectLighthouse.Tests.GameApiTests/UploadTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/UploadTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Tests;
+using LBPUnion.ProjectLighthouse.Types;
 using Xunit;
 
 namespace ProjectLighthouse.Tests.GameApiTests;
@@ -19,7 +20,9 @@ public class UploadTests : LighthouseServerTest
     [Fact]
     public async Task ShouldNotAcceptScript()
     {
-        HttpResponseMessage response = await this.UploadFileEndpointRequest("ExampleFiles/TestScript.ff");
+        LoginResult loginResult = await this.Authenticate();
+
+        HttpResponseMessage response = await this.AuthenticatedUploadFileEndpointRequest("ExampleFiles/TestScript.ff", loginResult.AuthTicket);
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);
         Assert.False(response.IsSuccessStatusCode);
     }
@@ -27,7 +30,9 @@ public class UploadTests : LighthouseServerTest
     [Fact]
     public async Task ShouldNotAcceptFarc()
     {
-        HttpResponseMessage response = await this.UploadFileEndpointRequest("ExampleFiles/TestFarc.farc");
+        LoginResult loginResult = await this.Authenticate();
+
+        HttpResponseMessage response = await this.AuthenticatedUploadFileEndpointRequest("ExampleFiles/TestFarc.farc", loginResult.AuthTicket);
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);
         Assert.False(response.IsSuccessStatusCode);
     }
@@ -35,7 +40,9 @@ public class UploadTests : LighthouseServerTest
     [Fact]
     public async Task ShouldNotAcceptGarbage()
     {
-        HttpResponseMessage response = await this.UploadFileEndpointRequest("ExampleFiles/TestGarbage.bin");
+        LoginResult loginResult = await this.Authenticate();
+
+        HttpResponseMessage response = await this.AuthenticatedUploadFileEndpointRequest("ExampleFiles/TestGarbage.bin", loginResult.AuthTicket);
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);
         Assert.False(response.IsSuccessStatusCode);
     }
@@ -43,7 +50,9 @@ public class UploadTests : LighthouseServerTest
     [Fact]
     public async Task ShouldAcceptTexture()
     {
-        HttpResponseMessage response = await this.UploadFileEndpointRequest("ExampleFiles/TestTexture.tex");
+        LoginResult loginResult = await this.Authenticate();
+
+        HttpResponseMessage response = await this.AuthenticatedUploadFileEndpointRequest("ExampleFiles/TestTexture.tex", loginResult.AuthTicket);
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);
         Assert.True(response.IsSuccessStatusCode);
     }
@@ -51,7 +60,9 @@ public class UploadTests : LighthouseServerTest
     [Fact]
     public async Task ShouldAcceptLevel()
     {
-        HttpResponseMessage response = await this.UploadFileEndpointRequest("ExampleFiles/TestLevel.lvl");
+        LoginResult loginResult = await this.Authenticate();
+
+        HttpResponseMessage response = await this.AuthenticatedUploadFileEndpointRequest("ExampleFiles/TestLevel.lvl", loginResult.AuthTicket);
         Assert.False(response.StatusCode == HttpStatusCode.Forbidden);
         Assert.True(response.IsSuccessStatusCode);
     }

--- a/ProjectLighthouse.Tests/LighthouseServerTest.cs
+++ b/ProjectLighthouse.Tests/LighthouseServerTest.cs
@@ -73,6 +73,16 @@ public class LighthouseServerTest
         return await this.Client.PostAsync($"/LITTLEBIGPLANETPS3_XML/upload/{hash}", new ByteArrayContent(bytes));
     }
 
+    public async Task<HttpResponseMessage> AuthenticatedUploadFileEndpointRequest(string filePath, string mmAuth)
+    {
+        byte[] bytes = await File.ReadAllBytesAsync(filePath);
+        string hash = HashHelper.Sha1Hash(bytes).ToLower();
+        using HttpRequestMessage requestMessage = new(HttpMethod.Post, $"/LITTLEBIGPLANETPS3_XML/upload/{hash}");
+        requestMessage.Headers.Add("Cookie", mmAuth);
+        requestMessage.Content = new ByteArrayContent(bytes);
+        return await this.Client.SendAsync(requestMessage);
+    }
+
     public async Task<HttpResponseMessage> UploadFileRequest(string endpoint, string filePath)
         => await this.Client.PostAsync(endpoint, new StringContent(await File.ReadAllTextAsync(filePath)));
 

--- a/ProjectLighthouse/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/CommentsPartial.cshtml
@@ -28,7 +28,6 @@
             </div>
             <input type="submit" class="ui blue button">
         </form>
-        <br>
     }
 
     @for(int i = 0; i < Model.Comments.Count; i++)

--- a/ProjectLighthouse/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse/Pages/Partials/SlotCardPartial.cshtml
@@ -51,7 +51,7 @@
         }
         <div class="cardStatsUnderTitle">
             <i class="pink heart icon" title="Hearts"></i> <span>@Model.Hearts</span>
-            <i class="blue play icon" title="Plays"></i> <span>@Model.Plays</span>
+            <i class="blue play icon" title="Plays"></i> <span>@Model.PlaysUnique</span>
             <i class="green thumbs up icon" title="Yays"></i> <span>@Model.Thumbsup</span>
             <i class="red thumbs down icon" title="Boos"></i> <span>@Model.Thumbsdown</span>
 

--- a/ProjectLighthouse/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse/Pages/SlotPage.cshtml
@@ -1,6 +1,7 @@
 @page "/slot/{id:int}"
 @using System.Web
 @using LBPUnion.ProjectLighthouse.Helpers.Extensions
+@using LBPUnion.ProjectLighthouse.Types
 @using LBPUnion.ProjectLighthouse.Types.Reviews
 @using LBPUnion.ProjectLighthouse.Types.Settings
 @model LBPUnion.ProjectLighthouse.Pages.SlotPage
@@ -81,15 +82,22 @@
             }
             <div class="ui divider"></div>
 
-            @foreach (Review review in Model.Reviews)
+            @for (int i = 0; i < Model.Reviews.Count; i++)
             {
+                Review review = Model.Reviews[i];
                 string faceHash = review.Thumb switch {
-                    -1 => review.Reviewer.BooHash,
-                    0 => review.Reviewer.MehHash,
-                    1 => review.Reviewer.YayHash,
+                    -1 => review.Reviewer?.BooHash,
+                    0 => review.Reviewer?.MehHash,
+                    1 => review.Reviewer?.YayHash,
                     
                     _ => throw new ArgumentOutOfRangeException(),
                     };
+
+                if (string.IsNullOrWhiteSpace(faceHash))
+                {
+                    faceHash = ServerSettings.Instance.MissingIconHash;
+                }
+
 
                 string faceAlt = review.Thumb switch {
                     -1 => "Boo!",
@@ -106,27 +114,50 @@
                         <img class="cardIcon slotCardIcon" src="@ServerSettings.Instance.ExternalUrl/gameAssets/@faceHash" alt="@faceAlt" title="@faceAlt" style="min-width: @(size)px; width: @(size)px; height: @(size)px">
                     </div>
                     <div class="cardStats">
-                        <h3 style="margin-bottom: 5px;">@review.Reviewer.Username</h3>
-                        @if (review.Labels.Length > 1)
+                        <h3 style="margin-bottom: 5px;">@review.Reviewer?.Username</h3>
+                        @if (review.Deleted)
                         {
-                            @foreach (string reviewLabel in review.Labels)
+                            if (review.DeletedBy == DeletedBy.LevelAuthor)
                             {
-                                <div class="ui blue label">@reviewLabel.Replace("LABEL_", "")</div>
+                                <p>
+                                    <i>This review has been deleted by the level author.</i>
+                                </p>
                             }
-                        }
-                        @if (string.IsNullOrWhiteSpace(review.Text))
-                        {
-                            <p>
-                                <i>This review contains no text.</i>
-                            </p>
+                            else
+                            {
+                                <p>
+                                    <i>This review has been deleted by a moderator.</i>
+                                </p>
+                            }
                         }
                         else
                         {
-                            <p>@review.Text</p>
+                            @if (review.Labels.Length > 1)
+                            {
+                                @foreach (string reviewLabel in review.Labels)
+                                {
+                                    <div class="ui blue label">@reviewLabel.Replace("LABEL_", "")</div>
+                                }
+                            }
+                            @if (string.IsNullOrWhiteSpace(review.Text))
+                            {
+                                <p>
+                                    <i>This review contains no text.</i>
+                                </p>
+                            }
+                            else
+                            {
+                                {
+                                    <p>@review.Text</p>
+                                }
+                            }
                         }
                     </div>
                 </div>
-                <br>
+                @if (i != Model.Reviews.Count - 1)
+                {
+                    <div class="ui divider"></div>
+                }
             }
         </div>
     </div>


### PR DESCRIPTION
# Fixes in this PR
* Reviews are no longer shown if they are deleted (closes #273)
* Reviews now show the missingIconHash if their hash is empty
* Slot version is preserved when republishing instead of defaulting to LBP1 (closes #274)
* Added the `/upload/[hash]/unattributed` endpoint (closes #269)
* Resource endpoints `/r`, `/upload`, `/filterResources` and `/showNotUploaded` now require authentication
* Website now displays play count as the number of unique plays (closes #192)

I also added a divider between reviews
![image](https://user-images.githubusercontent.com/16675503/163127290-f9452a02-21f6-451a-adf8-42034f7197d3.png)

