### PR TITLE
Set photo timestamp to current time if timestamp is in the future

### DIFF
--- a/ProjectLighthouse/Controllers/GameApi/Resources/PhotosController.cs
+++ b/ProjectLighthouse/Controllers/GameApi/Resources/PhotosController.cs
@@ -59,7 +59,7 @@ public class PhotosController : ControllerBase
 
         if (photo.Subjects.Count > 4) return this.BadRequest();
 
-        if (photo.Timestamp > TimestampHelper.Timestamp) return this.BadRequest();
+        if (photo.Timestamp > TimestampHelper.Timestamp) photo.Timestamp = TimestampHelper.Timestamp;
 
         foreach (PhotoSubject subject in photo.Subjects)
         {


### PR DESCRIPTION
Some people were unable to upload photos due to their console being set to the wrong time. I think this is a better solution rather than rejecting the request.