### PR TITLE
workaround for NETSDK1152 error

### DIFF
--- a/ProjectLighthouse.Servers.API/ProjectLighthouse.Servers.API.csproj
+++ b/ProjectLighthouse.Servers.API/ProjectLighthouse.Servers.API.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.API</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.API</RootNamespace>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/ProjectLighthouse.Servers.API/ProjectLighthouse.Servers.API.csproj
+++ b/ProjectLighthouse.Servers.API/ProjectLighthouse.Servers.API.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.API</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.API</RootNamespace>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/ProjectLighthouse.Servers.GameServer/ProjectLighthouse.Servers.GameServer.csproj
+++ b/ProjectLighthouse.Servers.GameServer/ProjectLighthouse.Servers.GameServer.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.GameServer</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.GameServer</RootNamespace>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse.Servers.GameServer/ProjectLighthouse.Servers.GameServer.csproj
+++ b/ProjectLighthouse.Servers.GameServer/ProjectLighthouse.Servers.GameServer.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.GameServer</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.GameServer</RootNamespace>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse.Servers.Website/ProjectLighthouse.Servers.Website.csproj
+++ b/ProjectLighthouse.Servers.Website/ProjectLighthouse.Servers.Website.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.Website</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.Website</RootNamespace>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse.Servers.Website/ProjectLighthouse.Servers.Website.csproj
+++ b/ProjectLighthouse.Servers.Website/ProjectLighthouse.Servers.Website.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblyName>LBPUnion.ProjectLighthouse.Servers.Website</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse.Servers.Website</RootNamespace>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse/ProjectLighthouse.csproj
+++ b/ProjectLighthouse/ProjectLighthouse.csproj
@@ -5,6 +5,7 @@
         <AssemblyName>LBPUnion.ProjectLighthouse</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse</RootNamespace>
         <OutputType>Library</OutputType>
+		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse/ProjectLighthouse.csproj
+++ b/ProjectLighthouse/ProjectLighthouse.csproj
@@ -5,7 +5,7 @@
         <AssemblyName>LBPUnion.ProjectLighthouse</AssemblyName>
         <RootNamespace>LBPUnion.ProjectLighthouse</RootNamespace>
         <OutputType>Library</OutputType>
-		<ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
gets rid of the "Found multiple publish output files with the same relative path" error i encountered while publishing from dotnet cli