### PR TITLE
Fix text wrap and slot titles

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
@@ -1,3 +1,4 @@
+@using System.Web
 @using LBPUnion.ProjectLighthouse
 @using LBPUnion.ProjectLighthouse.Configuration
 @using LBPUnion.ProjectLighthouse.PlayerData
@@ -10,8 +11,8 @@
 
     await using Database database = new();
 
-    string slotName = string.IsNullOrEmpty(Model.Name) ? "Unnamed Level" : Model.Name;
-    
+    string slotName = HttpUtility.HtmlDecode(string.IsNullOrEmpty(Model!.Name) ? "Unnamed Level" : Model.Name);
+
     bool isMobile = (bool?)ViewData["IsMobile"] ?? false;
     bool mini = (bool?)ViewData["IsMini"] ?? false;
 

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -4,15 +4,14 @@
 @using LBPUnion.ProjectLighthouse.Configuration
 @using LBPUnion.ProjectLighthouse.Extensions
 @using LBPUnion.ProjectLighthouse.PlayerData.Reviews
-@using LBPUnion.ProjectLighthouse.Types
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.SlotPage
 
 @{
     Layout = "Layouts/BaseLayout";
     Model.ShowTitleInPage = false;
 
-    Model.Title = Model.Slot?.Name ?? "";
-    Model.Description = Model.Slot?.Description ?? "";
+    Model.Title = HttpUtility.HtmlDecode(Model.Slot?.Name ?? "");
+    Model.Description = HttpUtility.HtmlDecode(Model.Slot?.Description ?? "");
 
     bool isMobile = this.Request.IsMobile();
 }
@@ -38,15 +37,14 @@
     <div class="eight wide column">
         <div class="ui blue segment">
             <h2>Description</h2>
-            <p>@HttpUtility.HtmlDecode(string.IsNullOrEmpty(Model.Slot?.Description) ? "This level has no description." : Model.Slot.Description)</p>
+            <p style="overflow-wrap: anywhere">@HttpUtility.HtmlDecode(string.IsNullOrEmpty(Model.Slot?.Description) ? "This level has no description." : Model.Slot.Description)</p>
         </div>
     </div>
     <div class="eight wide column">
         <div class="ui red segment">
             <h2>Tags</h2>
             @{
-                string[] authorLabels = Model.Slot?.AuthorLabels.Split(",") ?? new string[]
-                {};
+                string[] authorLabels = Model.Slot?.AuthorLabels.Split(",") ?? new string[]{};
                 if (authorLabels.Length == 1) // ..?? ok c#
                 {
                     <p>This level has no tags.</p>

--- a/ProjectLighthouse/PlayerData/Profiles/User.cs
+++ b/ProjectLighthouse/PlayerData/Profiles/User.cs
@@ -142,9 +142,11 @@ public class User
 
     [JsonIgnore]
     public string BannedReason { get; set; }
-    
+
+    #nullable enable
     [JsonIgnore]
     public string? ApprovedIPAddress { get; set; }
+    #nullable disable
 
     public string Serialize(GameVersion gameVersion = GameVersion.LittleBigPlanet1)
     {

--- a/ProjectLighthouse/StaticFiles/css/styles.css
+++ b/ProjectLighthouse/StaticFiles/css/styles.css
@@ -27,6 +27,7 @@ canvas.hide-subjects {
 
 .card {
     display: flex;
+    overflow-wrap: anywhere;
     width: 100%;
 }
 


### PR DESCRIPTION
This PR most notably fixes text overflowing from their containers on the front page, slot list, and the slot page itself. It also fixes HTML entities not being decoded in slot titles like `&gt;`. Closes #322.

This method does have some drawbacks like whole words sometimes being cut into two parts but otherwise, a single long word will not get wrapped.

# Examples
Before

![](https://i.imgur.com/m2IubY2.png)
![](https://i.imgur.com/4C9Z5LE.png)
![](https://i.imgur.com/3egv5Vy.png)


After

![](https://i.imgur.com/9DpKe3A.png)
![](https://i.imgur.com/SVYxpmR.png)
![](https://i.imgur.com/uqJ37qF.png)
