### PR TITLE
Update default language to be en instead of en-US

### DIFF
--- a/ProjectLighthouse.Localization/LocalizationManager.cs
+++ b/ProjectLighthouse.Localization/LocalizationManager.cs
@@ -7,7 +7,7 @@ namespace LBPUnion.ProjectLighthouse.Localization;
 public static class LocalizationManager
 {
     private static readonly string namespaceStr = typeof(LocalizationManager).Namespace ?? "";
-    public const string DefaultLang = "en-US";
+    public const string DefaultLang = "en";
 
     public static string GetLocalizedString(TranslationAreas translationArea, string language, string key)
     {
@@ -21,7 +21,7 @@ public static class LocalizationManager
 
         string resourceBasename = $"{namespaceStr}.{translationArea.ToString()}";
 
-        // We don't have an en-US .resx, so if we aren't using en-US then we need to add the appropriate language.
+        // We don't have an en .resx, so if we aren't using en then we need to add the appropriate language.
         // Otherwise, keep it to the normal .resx file
         // e.g. BaseLayout.resx as opposed to BaseLayout.lang-da-DK.resx.
         if (language != DefaultLang) resourceBasename += $".lang-{language}";

--- a/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
+++ b/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
@@ -45,7 +45,7 @@ public class WebsiteStartup
         {
             List<CultureInfo> languages = LocalizationManager.GetAvailableLanguages().Select(l => new CultureInfo(LocalizationManager.MapLanguage(l))).ToList();
 
-            config.DefaultRequestCulture = new RequestCulture(new CultureInfo("en-US"));
+            config.DefaultRequestCulture = new RequestCulture(new CultureInfo("en"));
 
             config.SupportedCultures = languages;
             config.SupportedUICultures = languages;


### PR DESCRIPTION
This allows browsers requesting over en-GB to still get the English version before another one.

Closes #384 