### PR TITLE
Keep announce text blank and allow EULA to be customized a little further in terms of layout.

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -84,7 +84,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
             $"token.ExpiresAt: {gameToken.ExpiresAt.ToString(CultureInfo.CurrentCulture)}\n" +
             "---DEBUG INFO---" +
             #endif
-            "\n"
+            (announceText != "" ? "\n" : "")
         );
     }
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -42,6 +42,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
         User? user = await this.database.UserFromGameRequest(this.Request);
         if (user == null) return this.StatusCode(403, "");
 
+        string eulaText = ServerConfiguration.Instance.EulaText;
+
+        eulaText = eulaText.Replace("%licence", $"{license}\n");
+        eulaText = eulaText.Replace("\\n", "\n"); // just in case, may be redundant
+
         return this.Ok($"{license}\n{ServerConfiguration.Instance.EulaText}");
     }
 

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -23,7 +23,7 @@ public class ServerConfiguration
     // You can use an ObsoleteAttribute instead. Make sure you set it to error, though.
     //
     // Thanks for listening~
-    public const int CurrentConfigVersion = 10;
+    public const int CurrentConfigVersion = 11;
 
     #region Meta
 
@@ -177,7 +177,7 @@ public class ServerConfiguration
     public string RedisConnectionString { get; set; } = "redis://localhost:6379";
     public string ExternalUrl { get; set; } = "http://localhost:10060";
     public bool ConfigReloading { get; set; }
-    public string EulaText { get; set; } = "";
+    public string EulaText { get; set; } = "%license";
 #if !DEBUG
     public string AnnounceText { get; set; } = "You are now logged in as %user.";
 #else


### PR DESCRIPTION
Changes message endpoints to make them more customizable, such as moving around the license to give a bit of important info before the license is given (such as where to find the rules governing the instance or whatever) and clearing out announce (as some people may find having to hit one extra button to get into the game a bit annoying ;P)

Doesn't allow people to remove license entirely from EULA though.

Resolves #380
Fixes #376