### PR TITLE
Fix posters' comments not showing ratings

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -52,7 +52,7 @@
                 string style = "";
                 if (Model.User?.UserId == comment.PosterUserId)
                 {
-                    style = "visibility: hidden";
+                    style = "pointer-events: none";
                 }
             }
             <div class="voting" style="@(style)">


### PR DESCRIPTION
The last time I touched comments I accidentally made the comment ratings invisible 
![image](https://user-images.githubusercontent.com/16675503/182307722-a6b93925-4299-4478-91c3-c078b19ba1fc.png)
This PR disables pointer events for the voting buttons instead of simply hiding them.
