### PR TITLE
Prevent grief report deletion from removing slot rootLevel

### DIFF
--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminReportController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminReportController.cs
@@ -31,8 +31,9 @@ public class AdminReportController : ControllerBase
         {
             report.JpegHash,
             report.GriefStateHash,
-            report.InitialStateHash,
         };
+        if(report.LevelType != "user")
+            hashes.Add(report.InitialStateHash);
         foreach (string hash in hashes)
         {
             if (System.IO.File.Exists(Path.Combine("png", $"{hash}.png")))


### PR DESCRIPTION
This kind of closes #353, I think it may also be a good idea to rename the remove all assets button because it insinuates that it will delete (unpublish) the level that the report was generated in.