### PR TITLE
Add support for deleting comments from the website

### DIFF
--- a/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
@@ -31,6 +31,17 @@ public class UserPageController : ControllerBase
         return this.Redirect($"~/user/{id}#{commentId}");
     }
 
+    [HttpGet("deleteComment/{commentId:int}")]
+    public async Task<IActionResult> DeleteComment([FromRoute] int id, [FromRoute] int commentId)
+    {
+        WebToken? token = this.database.WebTokenFromRequest(this.Request);
+        if (token == null) return this.Redirect("~/login");
+
+        await this.database.DeleteComment(token.UserId, commentId);
+
+        return this.Redirect($"~/user/{id}#comments");
+    }
+
     [HttpPost("postComment")]
     public async Task<IActionResult> PostComment([FromRoute] int id, [FromForm] string? msg)
     {

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -6,7 +6,17 @@
 
 @{
     string language = (string?)ViewData["Language"] ?? LocalizationManager.DefaultLang;
+
+    int slotCreatorId = (int?)ViewData["SlotCreatorId"] ?? 0;
 }
+
+<script>
+  function confirmDeletion(commentId){
+      if (window.confirm("Are you sure you want to delete this comment?\nThis action cannot be undone.")){
+          window.location.href = "@Url.RouteUrl(ViewContext.RouteData.Values)/deleteComment/" + commentId;
+      }          
+  }
+</script>
 
 <div class="ui yellow segment" id="comments">
     <h2>Comments</h2>
@@ -83,6 +93,12 @@
                 else
                 {
                     <span>@decodedMessage</span>
+                }
+                @if ((Model.User?.UserId == comment.PosterUserId || Model.User?.UserId == slotCreatorId) && !comment.Deleted)
+                {
+                    <button class="ui red icon button" style="display:inline-flex; float: right" onclick="confirmDeletion(@comment.CommentId)">
+                        <i class="trash icon"></i>
+                    </button>
                 }
                 <p>
                     <i>@timestamp.ToString("MM/dd/yyyy @ h:mm tt") UTC</i>

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -83,7 +83,11 @@
         <br/>
     }
     <div class="eight wide column">
-        @await Html.PartialAsync("Partials/CommentsPartial", ViewData.WithLang(language))
+        @{
+            ViewDataDictionary data = ViewData.WithLang(language);
+            data.Add("SlotCreatorId", Model.Slot!.CreatorId);
+        }
+        @await Html.PartialAsync("Partials/CommentsPartial", data)
     </div>
     @if (isMobile)
     {


### PR DESCRIPTION
This follows the same specification as the real game where users can delete their own comments and profile and level owners can delete any comment on their profile or level. It uses the browser's built-in confirmation dialog when pressing the delete button.
![](https://i.imgur.com/1r4oVgN.png)
![](https://i.imgur.com/mvzP6jt.png)
![](https://i.imgur.com/l68hfkj.png)

Closes #239 