### PR TITLE
Fix photos with me and more

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -200,7 +200,7 @@ public class PhotosController : ControllerBase
             p.PhotoId,
             p.PhotoSubjectCollection,
         }).ToList();
-        List<int> photoIds = (from v in list where photoSubjectIds.Any(ps => v.PhotoSubjectCollection.Contains(ps.ToString())) select v.PhotoId).ToList();
+        List<int> photoIds = (from v in list where photoSubjectIds.Any(ps => v.PhotoSubjectCollection.Split(",").Contains(ps.ToString())) select v.PhotoId).ToList();
 
         string response = Enumerable.Aggregate(
             this.database.Photos.Where(p => photoIds.Any(id => p.PhotoId == id) && p.CreatorId != targetUserId)
@@ -221,7 +221,12 @@ public class PhotosController : ControllerBase
 
         Photo? photo = await this.database.Photos.FirstOrDefaultAsync(p => p.PhotoId == id);
         if (photo == null) return this.NotFound();
-        if (photo.CreatorId != token.UserId) return this.StatusCode(401, "");
+        if (photo.CreatorId != token.UserId)
+        {
+            Slot? photoSlot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == photo.SlotId && s.Type == SlotType.User);
+            if (photoSlot == null || photoSlot.CreatorId != token.UserId) return this.StatusCode(401, "");
+        }
+
         foreach (string idStr in photo.PhotoSubjectIds)
         {
             if (!int.TryParse(idStr, out int subjectId)) throw new InvalidCastException(idStr + " is not a valid number.");

--- a/ProjectLighthouse.Servers.Website/Extensions/PartialExtensions.cs
+++ b/ProjectLighthouse.Servers.Website/Extensions/PartialExtensions.cs
@@ -1,4 +1,3 @@
-using LBPUnion.ProjectLighthouse.Levels;
 using LBPUnion.ProjectLighthouse.PlayerData;
 using LBPUnion.ProjectLighthouse.PlayerData.Profiles;
 using Microsoft.AspNetCore.Html;
@@ -27,8 +26,23 @@ public static class PartialExtensions
         }
     }
 
-    public static Task<IHtmlContent> ToLink<T>(this User user, IHtmlHelper<T> helper, ViewDataDictionary<T> viewData, string language) 
-        => helper.PartialAsync("Partials/Links/UserLinkPartial", user, viewData.WithLang(language));
+    public static Task<IHtmlContent> ToLink<T>
+    (
+        this User user,
+        IHtmlHelper<T> helper,
+        ViewDataDictionary<T> viewData,
+        string language,
+        bool includeUserStatus = false
+    )
+    {
+        if(viewData.ContainsKey("IncludeStatus"))
+            viewData.Remove("IncludeStatus");
+        if(includeUserStatus)
+            viewData.Add("IncludeStatus", true);
+
+        return helper.PartialAsync("Partials/Links/UserLinkPartial", user, viewData.WithLang(language));
+    } 
+        
 
     public static Task<IHtmlContent> ToHtml<T>(this Photo photo, IHtmlHelper<T> helper, ViewDataDictionary<T> viewData, string language)
         => helper.PartialAsync("Partials/PhotoPartial", photo, viewData.WithLang(language));

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
@@ -48,7 +48,7 @@ else
     foreach (User user in Model.PlayersOnline)
     {
         i++; 
-        @await user.ToLink(Html, ViewData, language)if (i != Model.PlayersOnline.Count){<span>,</span>} @* whitespace has forced my hand *@
+        @await user.ToLink(Html, ViewData, language, true) if (i != Model.PlayersOnline.Count){<span>,</span>} @* whitespace has forced my hand *@
     }
 }
 

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
@@ -3,9 +3,14 @@
 
 @{
     string language = (string?)ViewData["Language"] ?? LocalizationManager.DefaultLang;
+    string status = "";
+    if ((bool)(ViewData["IncludeStatus"] ?? false))
+    {
+        status = Model.Status.ToTranslatedString(language);
+    }
 }
 
-<a href="/user/@Model.UserId" title="@Model.Status.ToTranslatedString(language)" class="user-link">
+<a href="/user/@Model.UserId" title="@status" class="user-link">
     <img src="/gameAssets/@Model.WebsiteAvatarHash" alt=""/>
     @Model.Username
 </a>

--- a/ProjectLighthouse/PlayerData/Profiles/User.cs
+++ b/ProjectLighthouse/PlayerData/Profiles/User.cs
@@ -93,7 +93,7 @@ public class User
                 p.PhotoId,
                 p.PhotoSubjectCollection,
             }).ToList();
-        List<int> photoIds = (from v in list where photoSubjectIds.Any(ps => v.PhotoSubjectCollection.Contains(ps.ToString())) select v.PhotoId).ToList();
+        List<int> photoIds = (from v in list where photoSubjectIds.Any(ps => v.PhotoSubjectCollection.Split(",").Contains(ps.ToString())) select v.PhotoId).ToList();
         return this.database.Photos.Count(p => photoIds.Any(pId => p.PhotoId == pId) && p.CreatorId != this.UserId);
     }
 


### PR DESCRIPTION
This PR fixes where the photos with me category would contain photos that definitely weren't with you. This also allows level owners to delete photos from their levels. Lastly, this PR removes the user status that appears when you hover over a linked user in lieu of it only showing up on the home page. This should help alleviate some of the performance issues that came with the website makeover.

Closes #448 