### PR TITLE
Implement POST request rate limiting

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -185,7 +185,8 @@ public class PublishController : ControllerBase
                 if (intendedVersion != GameVersion.Unknown && intendedVersion != slotVersion)
                 {
                     // Delete the useless rootLevel that lbp3 just uploaded
-                    FileHelper.DeleteResource(slot.RootLevel);
+                    if(slotVersion == GameVersion.LittleBigPlanet3)
+                        FileHelper.DeleteResource(slot.RootLevel);
 
                     slot.GameVersion = oldSlot.GameVersion;
                     slot.RootLevel = oldSlot.RootLevel;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -60,12 +60,12 @@ public class PublishController : ControllerBase
             Slot? oldSlot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == slot.SlotId);
             if (oldSlot == null)
             {
-                Logger.Warn("Rejecting level reupload, could not find old slot", LogArea.Publish);
+                Logger.Warn("Rejecting level republish, could not find old slot", LogArea.Publish);
                 return this.NotFound();
             }
             if (oldSlot.CreatorId != user.UserId)
             {
-                Logger.Warn("Rejecting level reupload, old slot's creator is not publishing user", LogArea.Publish);
+                Logger.Warn("Rejecting level republish, old slot's creator is not publishing user", LogArea.Publish);
                 return this.BadRequest();
             }
         }
@@ -87,7 +87,7 @@ public class PublishController : ControllerBase
     ///     Endpoint actually used to publish a level
     /// </summary>
     [HttpPost("publish")]
-    public async Task<IActionResult> Publish()
+    public async Task<IActionResult> Publish([FromQuery] string? game)
     {
         (User, GameToken)? userAndToken = await this.database.UserAndGameTokenFromRequest(this.Request);
 
@@ -176,6 +176,21 @@ public class PublishController : ControllerBase
             {
                 Logger.Warn("Rejecting level republish, old level not owned by current user", LogArea.Publish);
                 return this.BadRequest();
+            }
+
+            // I hate lbp3
+            if (game != null)
+            {
+                GameVersion intendedVersion = FromAbbreviation(game);
+                if (intendedVersion != GameVersion.Unknown && intendedVersion != slotVersion)
+                {
+                    // Delete the useless rootLevel that lbp3 just uploaded
+                    FileHelper.DeleteResource(slot.RootLevel);
+
+                    slot.GameVersion = oldSlot.GameVersion;
+                    slot.RootLevel = oldSlot.RootLevel;
+                    slot.ResourceCollection = oldSlot.ResourceCollection;
+                }
             }
 
             oldSlot.Location.X = slot.Location.X;
@@ -275,6 +290,19 @@ public class PublishController : ControllerBase
         await this.database.SaveChangesAsync();
 
         return this.Ok();
+    }
+
+    private static GameVersion FromAbbreviation(string abbr)
+    {
+        return abbr switch
+        {
+            "lbp1" => GameVersion.LittleBigPlanet1,
+            "lbp2" => GameVersion.LittleBigPlanet2,
+            "lbp3" => GameVersion.LittleBigPlanet3,
+            "lbpv" => GameVersion.LittleBigPlanetVita,
+            "lbppsp" => GameVersion.LittleBigPlanetPSP,
+            _ => GameVersion.Unknown,
+        };
     }
 
     private async Task<Slot?> getSlotFromBody()

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
@@ -1,0 +1,125 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Middlewares;
+using Microsoft.Extensions.Primitives;
+
+namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Middlewares;
+
+public class DigestMiddleware : Middleware
+{
+    private readonly bool computeDigests;
+
+    public DigestMiddleware(RequestDelegate next, bool computeDigests) : base(next)
+    {
+        this.computeDigests = computeDigests;
+    }
+
+    public override async Task InvokeAsync(HttpContext context)
+    {
+        // Client digest check.
+        if (!context.Request.Cookies.TryGetValue("MM_AUTH", out string? authCookie) || authCookie == null)
+            authCookie = string.Empty;
+        string digestPath = context.Request.Path;
+        #if !DEBUG
+        const string url = "/LITTLEBIGPLANETPS3_XML";
+        string strippedPath = digestPath.Contains(url) ? digestPath[url.Length..] : "";
+        #endif
+        Stream body = context.Request.Body;
+
+        bool usedAlternateDigestKey = false;
+
+        if (computeDigests && digestPath.StartsWith("/LITTLEBIGPLANETPS3_XML"))
+        {
+            // The game sets X-Digest-B on a resource upload instead of X-Digest-A
+            string digestHeaderKey = "X-Digest-A";
+            bool excludeBodyFromDigest = false;
+            if (digestPath.Contains("/upload/"))
+            {
+                digestHeaderKey = "X-Digest-B";
+                excludeBodyFromDigest = true;
+            }
+
+            string clientRequestDigest = await CryptoHelper.ComputeDigest(digestPath,
+                authCookie,
+                body,
+                ServerConfiguration.Instance.DigestKey.PrimaryDigestKey,
+                excludeBodyFromDigest);
+
+            // Check the digest we've just calculated against the digest header if the game set the header. They should match.
+            if (context.Request.Headers.TryGetValue(digestHeaderKey, out StringValues sentDigest))
+            {
+                if (clientRequestDigest != sentDigest)
+                {
+                    // If we got here, the normal ServerDigestKey failed to validate. Lets try again with the alternate digest key.
+                    usedAlternateDigestKey = true;
+
+                    // Reset the body stream
+                    body.Position = 0;
+
+                    clientRequestDigest = await CryptoHelper.ComputeDigest(digestPath,
+                        authCookie,
+                        body,
+                        ServerConfiguration.Instance.DigestKey.AlternateDigestKey,
+                        excludeBodyFromDigest);
+                    if (clientRequestDigest != sentDigest)
+                    {
+                        #if DEBUG
+                        Console.WriteLine("Digest failed");
+                        Console.WriteLine("digestKey: " + ServerConfiguration.Instance.DigestKey.PrimaryDigestKey);
+                        Console.WriteLine("altDigestKey: " + ServerConfiguration.Instance.DigestKey.AlternateDigestKey);
+                        Console.WriteLine("computed digest: " + clientRequestDigest);
+                        #endif
+                        // We still failed to validate. Abort the request.
+                        context.Response.StatusCode = 403;
+                        return;
+                    }
+                }
+            }
+            #if !DEBUG
+            // The game doesn't start sending digests until after the announcement so if it's not one of those requests
+            // and it doesn't include a digest we need to reject the request 
+            else if (!ServerStatics.IsUnitTesting && !strippedPath.Equals("/login") && !strippedPath.Equals("/eula") 
+                     && !strippedPath.Equals("/announce") && !strippedPath.Equals("/status") && !strippedPath.Equals("/farc_hashes"))
+            {
+                context.Response.StatusCode = 403;
+                return;
+            }
+            #endif
+
+            context.Response.Headers.Add("X-Digest-B", clientRequestDigest);
+            context.Request.Body.Position = 0;
+        }
+
+        // This does the same as above, but for the response stream.
+        await using MemoryStream responseBuffer = new();
+        Stream oldResponseStream = context.Response.Body;
+        context.Response.Body = responseBuffer;
+
+        await this.next(context); // Handle the request so we can get the server digest hash
+        responseBuffer.Position = 0;
+
+        // Compute the server digest hash.
+        if (computeDigests)
+        {
+            responseBuffer.Position = 0;
+
+            string digestKey = usedAlternateDigestKey
+                ? ServerConfiguration.Instance.DigestKey.AlternateDigestKey
+                : ServerConfiguration.Instance.DigestKey.PrimaryDigestKey;
+
+            // Compute the digest for the response.
+            string serverDigest =
+                await CryptoHelper.ComputeDigest(context.Request.Path, authCookie, responseBuffer, digestKey);
+            context.Response.Headers.Add("X-Digest-A", serverDigest);
+        }
+
+        // Add a content-length header if it isn't present to disable response chunking
+        if (!context.Response.Headers.ContainsKey("Content-Length"))
+            context.Response.Headers.Add("Content-Length", responseBuffer.Length.ToString());
+
+        // Copy the buffered response to the actual response stream.
+        responseBuffer.Position = 0;
+        await responseBuffer.CopyToAsync(oldResponseStream);
+        context.Response.Body = oldResponseStream;
+    }
+}

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
@@ -28,7 +28,7 @@ public class DigestMiddleware : Middleware
 
         bool usedAlternateDigestKey = false;
 
-        if (computeDigests && digestPath.StartsWith("/LITTLEBIGPLANETPS3_XML"))
+        if (this.computeDigests && digestPath.StartsWith("/LITTLEBIGPLANETPS3_XML"))
         {
             // The game sets X-Digest-B on a resource upload instead of X-Digest-A
             string digestHeaderKey = "X-Digest-A";
@@ -99,7 +99,7 @@ public class DigestMiddleware : Middleware
         responseBuffer.Position = 0;
 
         // Compute the server digest hash.
-        if (computeDigests)
+        if (this.computeDigests)
         {
             responseBuffer.Position = 0;
 

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
@@ -39,11 +39,8 @@ public class DigestMiddleware : Middleware
                 excludeBodyFromDigest = true;
             }
 
-            string clientRequestDigest = await CryptoHelper.ComputeDigest(digestPath,
-                authCookie,
-                body,
-                ServerConfiguration.Instance.DigestKey.PrimaryDigestKey,
-                excludeBodyFromDigest);
+            string clientRequestDigest = await CryptoHelper.ComputeDigest
+                (digestPath, authCookie, body, ServerConfiguration.Instance.DigestKey.PrimaryDigestKey, excludeBodyFromDigest);
 
             // Check the digest we've just calculated against the digest header if the game set the header. They should match.
             if (context.Request.Headers.TryGetValue(digestHeaderKey, out StringValues sentDigest))
@@ -56,11 +53,8 @@ public class DigestMiddleware : Middleware
                     // Reset the body stream
                     body.Position = 0;
 
-                    clientRequestDigest = await CryptoHelper.ComputeDigest(digestPath,
-                        authCookie,
-                        body,
-                        ServerConfiguration.Instance.DigestKey.AlternateDigestKey,
-                        excludeBodyFromDigest);
+                    clientRequestDigest = await CryptoHelper.ComputeDigest
+                        (digestPath, authCookie, body, ServerConfiguration.Instance.DigestKey.AlternateDigestKey, excludeBodyFromDigest);
                     if (clientRequestDigest != sentDigest)
                     {
                         #if DEBUG
@@ -108,8 +102,7 @@ public class DigestMiddleware : Middleware
                 : ServerConfiguration.Instance.DigestKey.PrimaryDigestKey;
 
             // Compute the digest for the response.
-            string serverDigest =
-                await CryptoHelper.ComputeDigest(context.Request.Path, authCookie, responseBuffer, digestKey);
+            string serverDigest = await CryptoHelper.ComputeDigest(context.Request.Path, authCookie, responseBuffer, digestKey);
             context.Response.Headers.Add("X-Digest-A", serverDigest);
         }
 

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/SetLastContactMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/SetLastContactMiddleware.cs
@@ -1,0 +1,31 @@
+using LBPUnion.ProjectLighthouse.Middlewares;
+using LBPUnion.ProjectLighthouse.PlayerData;
+
+namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Middlewares;
+
+public class SetLastContactMiddleware : MiddlewareDBContext
+{
+    public SetLastContactMiddleware(RequestDelegate next) : base(next)
+    { }
+
+    public override async Task InvokeAsync(HttpContext context, Database database)
+    {
+        #nullable enable
+        // Log LastContact for LBP1. This is done on LBP2/3/V on a Match request.
+        if (context.Request.Path.ToString().StartsWith("/LITTLEBIGPLANETPS3_XML"))
+        {
+            // We begin by grabbing a token from the request, if this is a LBPPS3_XML request of course.
+            GameToken? gameToken = await database.GameTokenFromRequest(context.Request);
+
+            if (gameToken != null && gameToken.GameVersion == GameVersion.LittleBigPlanet1)
+                // Ignore UserFromGameToken null because user must exist for a token to exist
+                await LastContactHelper.SetLastContact(database,
+                    (await database.UserFromGameToken(gameToken))!,
+                    GameVersion.LittleBigPlanet1,
+                    gameToken.Platform);
+        }
+        #nullable disable
+
+        await this.next(context);
+    }
+}

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/SetLastContactMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/SetLastContactMiddleware.cs
@@ -17,12 +17,10 @@ public class SetLastContactMiddleware : MiddlewareDBContext
             // We begin by grabbing a token from the request, if this is a LBPPS3_XML request of course.
             GameToken? gameToken = await database.GameTokenFromRequest(context.Request);
 
-            if (gameToken != null && gameToken.GameVersion == GameVersion.LittleBigPlanet1)
+            if (gameToken?.GameVersion == GameVersion.LittleBigPlanet1)
                 // Ignore UserFromGameToken null because user must exist for a token to exist
-                await LastContactHelper.SetLastContact(database,
-                    (await database.UserFromGameToken(gameToken))!,
-                    GameVersion.LittleBigPlanet1,
-                    gameToken.Platform);
+                await LastContactHelper.SetLastContact
+                    (database, (await database.UserFromGameToken(gameToken))!, GameVersion.LittleBigPlanet1, gameToken.Platform);
         }
         #nullable disable
 

--- a/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
+++ b/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
@@ -1,11 +1,9 @@
 using LBPUnion.ProjectLighthouse.Configuration;
-using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Middlewares;
-using LBPUnion.ProjectLighthouse.PlayerData;
 using LBPUnion.ProjectLighthouse.Serialization;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Middlewares;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.Extensions.Primitives;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Startup;
 
@@ -66,134 +64,9 @@ public class GameServerStartup
         app.UseForwardedHeaders();
 
         app.UseMiddleware<RequestLogMiddleware>();
-
-        // Digest check
-        app.Use
-        (
-            async (context, next) =>
-            {
-                // Client digest check.
-                if (!context.Request.Cookies.TryGetValue("MM_AUTH", out string? authCookie) || authCookie == null) authCookie = string.Empty;
-                string digestPath = context.Request.Path;
-                #if !DEBUG
-                const string url = "/LITTLEBIGPLANETPS3_XML";
-                string strippedPath = digestPath.Contains(url) ? digestPath[url.Length..] : "";
-                #endif
-                Stream body = context.Request.Body;
-
-                bool usedAlternateDigestKey = false;
-
-                if (computeDigests && digestPath.StartsWith("/LITTLEBIGPLANETPS3_XML"))
-                {
-                    // The game sets X-Digest-B on a resource upload instead of X-Digest-A
-                    string digestHeaderKey = "X-Digest-A";
-                    bool excludeBodyFromDigest = false;
-                    if (digestPath.Contains("/upload/"))
-                    {
-                        digestHeaderKey = "X-Digest-B";
-                        excludeBodyFromDigest = true;
-                    }
-
-                    string clientRequestDigest = await CryptoHelper.ComputeDigest
-                        (digestPath, authCookie, body, ServerConfiguration.Instance.DigestKey.PrimaryDigestKey, excludeBodyFromDigest);
-
-                    // Check the digest we've just calculated against the digest header if the game set the header. They should match.
-                    if (context.Request.Headers.TryGetValue(digestHeaderKey, out StringValues sentDigest))
-                    {
-                        if (clientRequestDigest != sentDigest)
-                        {
-                            // If we got here, the normal ServerDigestKey failed to validate. Lets try again with the alternate digest key.
-                            usedAlternateDigestKey = true;
-
-                            // Reset the body stream
-                            body.Position = 0;
-
-                            clientRequestDigest = await CryptoHelper.ComputeDigest
-                                (digestPath, authCookie, body, ServerConfiguration.Instance.DigestKey.AlternateDigestKey, excludeBodyFromDigest);
-                            if (clientRequestDigest != sentDigest)
-                            {
-                                #if DEBUG
-                                Console.WriteLine("Digest failed");
-                                Console.WriteLine("digestKey: " + ServerConfiguration.Instance.DigestKey.PrimaryDigestKey);
-                                Console.WriteLine("altDigestKey: " + ServerConfiguration.Instance.DigestKey.AlternateDigestKey);
-                                Console.WriteLine("computed digest: " + clientRequestDigest);
-                                #endif
-                                // We still failed to validate. Abort the request.
-                                context.Response.StatusCode = 403;
-                                return;
-                            }
-                        }
-                    }
-                    #if !DEBUG
-                    // The game doesn't start sending digests until after the announcement so if it's not one of those requests
-                    // and it doesn't include a digest we need to reject the request 
-                    else if (!ServerStatics.IsUnitTesting && !strippedPath.Equals("/login") && !strippedPath.Equals("/eula") 
-                             && !strippedPath.Equals("/announce") && !strippedPath.Equals("/status") && !strippedPath.Equals("/farc_hashes"))
-                    {
-                        context.Response.StatusCode = 403;
-                        return;
-                    }
-                    #endif
-
-                    context.Response.Headers.Add("X-Digest-B", clientRequestDigest);
-                    context.Request.Body.Position = 0;
-                }
-
-                // This does the same as above, but for the response stream.
-                await using MemoryStream responseBuffer = new();
-                Stream oldResponseStream = context.Response.Body;
-                context.Response.Body = responseBuffer;
-
-                await next(context); // Handle the request so we can get the server digest hash
-                responseBuffer.Position = 0;
-
-                // Compute the server digest hash.
-                if (computeDigests)
-                {
-                    responseBuffer.Position = 0;
-
-                    string digestKey = usedAlternateDigestKey
-                        ? ServerConfiguration.Instance.DigestKey.AlternateDigestKey
-                        : ServerConfiguration.Instance.DigestKey.PrimaryDigestKey;
-
-                    // Compute the digest for the response.
-                    string serverDigest = await CryptoHelper.ComputeDigest(context.Request.Path, authCookie, responseBuffer, digestKey);
-                    context.Response.Headers.Add("X-Digest-A", serverDigest);
-                }
-
-                // Add a content-length header if it isn't present to disable response chunking
-                if(!context.Response.Headers.ContainsKey("Content-Length"))
-                    context.Response.Headers.Add("Content-Length", responseBuffer.Length.ToString());
-
-                // Copy the buffered response to the actual response stream.
-                responseBuffer.Position = 0;
-                await responseBuffer.CopyToAsync(oldResponseStream);
-                context.Response.Body = oldResponseStream;
-            }
-        );
-
-        app.Use
-        (
-            async (context, next) =>
-            {
-                #nullable enable
-                // Log LastContact for LBP1. This is done on LBP2/3/V on a Match request.
-                if (context.Request.Path.ToString().StartsWith("/LITTLEBIGPLANETPS3_XML"))
-                {
-                    // We begin by grabbing a token from the request, if this is a LBPPS3_XML request of course.
-                    await using Database database = new(); // Gets nuked at the end of the scope
-                    GameToken? gameToken = await database.GameTokenFromRequest(context.Request);
-
-                    if (gameToken != null && gameToken.GameVersion == GameVersion.LittleBigPlanet1)
-                        // Ignore UserFromGameToken null because user must exist for a token to exist
-                        await LastContactHelper.SetLastContact
-                            (database, (await database.UserFromGameToken(gameToken))!, GameVersion.LittleBigPlanet1, gameToken.Platform);
-                }
-                #nullable disable
-
-                await next(context);
-            }
-        );
+        app.UseMiddleware<DigestMiddleware>(computeDigests);
+        app.UseMiddleware<SetLastContactMiddleware>();
+        app.UseMiddleware<RateLimitMiddleware>();
 
         app.UseRouting();
 

--- a/ProjectLighthouse.Servers.Website/Pages/SendVerificationEmailPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SendVerificationEmailPage.cshtml
@@ -13,7 +13,8 @@
 }
 else
 {
-    <p>Failed to send email, please try again later</p>
+    <p>Failed to send email, please try again later.</p>
+    <p>If this issue persists please contact an Administrator</p>
 }
 
 <a href="/login/sendVerificationEmail">

--- a/ProjectLighthouse.Servers.Website/Pages/SendVerificationEmailPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SendVerificationEmailPage.cshtml.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.PlayerData.Profiles;
 using LBPUnion.ProjectLighthouse.PlayerData.Profiles.Email;
@@ -13,6 +14,9 @@ public class SendVerificationEmailPage : BaseLayout
 {
     public SendVerificationEmailPage(Database database) : base(database)
     {}
+
+    // (User id, timestamp of last request + 30 seconds)
+    private static readonly Dictionary<int, long> recentlySentEmail = new();
 
     public bool Success { get; set; }
 
@@ -35,21 +39,33 @@ public class SendVerificationEmailPage : BaseLayout
         }
         #endif
 
-        EmailVerificationToken? verifyToken = await this.Database.EmailVerificationTokens.FirstOrDefaultAsync(v => v.UserId == user.UserId); 
-        // If user doesn't have a token or it is expired then regenerate
-        if (verifyToken == null || DateTime.Now > verifyToken.ExpiresAt)
+        // Remove expired entries
+        for (int i = recentlySentEmail.Count - 1; i >= 0; i--)
         {
-            verifyToken = new EmailVerificationToken
-            {
-                UserId = user.UserId,
-                User = user,
-                EmailToken = CryptoHelper.GenerateAuthToken(),
-                ExpiresAt = DateTime.Now.AddHours(6),
-            };
-
-            this.Database.EmailVerificationTokens.Add(verifyToken);
-            await this.Database.SaveChangesAsync();
+            KeyValuePair<int, long> entry = recentlySentEmail.ElementAt(i);
+            if (TimeHelper.TimestampMillis > recentlySentEmail[user.UserId]) recentlySentEmail.Remove(entry.Key);
         }
+
+        if (recentlySentEmail.ContainsKey(user.UserId) && recentlySentEmail[user.UserId] > TimeHelper.TimestampMillis)
+        {
+            this.Success = true;
+            return this.Page();
+        }
+
+        string? existingToken = await this.Database.EmailVerificationTokens.Where(v => v.UserId == user.UserId).Select(v => v.EmailToken).FirstOrDefaultAsync();
+        if(existingToken != null)
+            this.Database.EmailVerificationTokens.RemoveWhere(t => t.EmailToken == existingToken);
+
+        EmailVerificationToken verifyToken = new()
+        {
+            UserId = user.UserId,
+            User = user,
+            EmailToken = CryptoHelper.GenerateAuthToken(),
+            ExpiresAt = DateTime.Now.AddHours(6),
+        };
+
+        this.Database.EmailVerificationTokens.Add(verifyToken);
+        await this.Database.SaveChangesAsync();
 
         string body = "Hello,\n\n" +
                       $"This email is a request to verify this email for your (likely new!) Project Lighthouse account ({user.Username}).\n\n" +
@@ -57,6 +73,9 @@ public class SendVerificationEmailPage : BaseLayout
                       "If this wasn't you, feel free to ignore this email.";
 
         this.Success = SMTPHelper.SendEmail(user.EmailAddress, "Project Lighthouse Email Verification", body);
+
+        // Don't send another email for 30 seconds
+        recentlySentEmail.Add(user.UserId, TimeHelper.TimestampMillis + 30 * 1000);
 
         return this.Page();
     }

--- a/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
+++ b/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
@@ -81,6 +81,7 @@ public class WebsiteStartup
         app.UseMiddleware<HandlePageErrorMiddleware>();
         app.UseMiddleware<RequestLogMiddleware>();
         app.UseMiddleware<UserRequiredRedirectMiddleware>();
+        app.UseMiddleware<RateLimitMiddleware>();
 
         app.UseRouting();
 

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/AuthenticationConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/AuthenticationConfiguration.cs
@@ -4,9 +4,6 @@ namespace LBPUnion.ProjectLighthouse.Configuration.ConfigurationCategories;
 
 public class AuthenticationConfiguration
 {
-    [Obsolete("Obsolete. This feature has been removed.", true)]
-    public bool BlockDeniedUsers { get; set; }
-
     public bool RegistrationEnabled { get; set; } = true;
     public bool PrivateRegistration { get; set; } = false;
     public bool UseExternalAuth { get; set; }

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
@@ -6,5 +6,5 @@ public class RateLimitConfiguration
 {
     public int RequestsPerInterval { get; set; } = 10;
     public int RequestInterval { get; set; } = 30;
-    public Dictionary<string, RateLimitOverride> RateLimitOverrides { get; set; } = new() { { "/upload", new RateLimitOverride() }, };
+    public Dictionary<string, RateLimitOverride> RateLimitOverrides { get; set; } = new() { { "/example/*/wildcard", new RateLimitOverride() }, };
 }

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace LBPUnion.ProjectLighthouse.Configuration.ConfigurationCategories;
+
+public class RateLimitConfiguration
+{
+    public int RequestsPerInterval { get; set; } = 10;
+    public int RequestInterval { get; set; } = 30;
+    public Dictionary<string, RateLimitOverride> RateLimitOverrides { get; set; } = new() { { "/upload", new RateLimitOverride() }, };
+}

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
@@ -4,7 +4,17 @@ namespace LBPUnion.ProjectLighthouse.Configuration.ConfigurationCategories;
 
 public class RateLimitConfiguration
 {
-    public int RequestsPerInterval { get; set; } = 10;
-    public int RequestInterval { get; set; } = 30;
-    public Dictionary<string, RateLimitOverride> RateLimitOverrides { get; set; } = new() { { "/example/*/wildcard", new RateLimitOverride() }, };
+    public RateLimitOptions GlobalOptions { get; set; } = new();
+
+    public Dictionary<string, RateLimitOptions> RateLimitOverrides { get; set; } = new()
+    {
+        {
+            "/example/*/wildcard", new RateLimitOptions
+            {
+                RequestInterval = 5,
+                RequestsPerInterval = 10,
+                Enabled = true,
+            }
+        },
+    };
 }

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/RateLimitConfiguration.cs
@@ -6,7 +6,7 @@ public class RateLimitConfiguration
 {
     public RateLimitOptions GlobalOptions { get; set; } = new();
 
-    public Dictionary<string, RateLimitOptions> RateLimitOverrides { get; set; } = new()
+    public Dictionary<string, RateLimitOptions> OverrideOptions { get; set; } = new()
     {
         {
             "/example/*/wildcard", new RateLimitOptions

--- a/ProjectLighthouse/Configuration/RateLimitOptions.cs
+++ b/ProjectLighthouse/Configuration/RateLimitOptions.cs
@@ -2,7 +2,7 @@
 
 public class RateLimitOptions
 {
-    public bool Enabled = true;
+    public bool Enabled = false;
     public int RequestsPerInterval { get; set; } = 5;
     public int RequestInterval { get; set; } = 15;
 }

--- a/ProjectLighthouse/Configuration/RateLimitOptions.cs
+++ b/ProjectLighthouse/Configuration/RateLimitOptions.cs
@@ -1,7 +1,8 @@
 ﻿namespace LBPUnion.ProjectLighthouse.Configuration;
 
-public class RateLimitOverride
+public class RateLimitOptions
 {
+    public bool Enabled = true;
     public int RequestsPerInterval { get; set; } = 5;
     public int RequestInterval { get; set; } = 15;
 }

--- a/ProjectLighthouse/Configuration/RateLimitOverride.cs
+++ b/ProjectLighthouse/Configuration/RateLimitOverride.cs
@@ -1,0 +1,7 @@
+﻿namespace LBPUnion.ProjectLighthouse.Configuration;
+
+public class RateLimitOverride
+{
+    public int RequestsPerInterval { get; set; } = 5;
+    public int RequestInterval { get; set; } = 15;
+}

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -23,7 +23,7 @@ public class ServerConfiguration
     // You can use an ObsoleteAttribute instead. Make sure you set it to error, though.
     //
     // Thanks for listening~
-    public const int CurrentConfigVersion = 10;
+    public const int CurrentConfigVersion = 11;
 
     #region Meta
 
@@ -39,7 +39,7 @@ public class ServerConfiguration
 
     #region Setup
 
-    private static FileSystemWatcher fileWatcher;
+    private static readonly FileSystemWatcher fileWatcher;
 
     // ReSharper disable once NotNullMemberIsNotInitialized
 #pragma warning disable CS8618
@@ -99,46 +99,55 @@ public class ServerConfiguration
         }
 
         // Set up reloading
-        if (Instance.ConfigReloading)
+        if (!Instance.ConfigReloading) return;
+
+        Logger.Info("Setting up config reloading...", LogArea.Config);
+        fileWatcher = new FileSystemWatcher
         {
-            Logger.Info("Setting up config reloading...", LogArea.Config);
-            fileWatcher = new FileSystemWatcher
-            {
-                Path = Environment.CurrentDirectory,
-                Filter = ConfigFileName,
-                NotifyFilter = NotifyFilters.LastWrite, // only watch for writes to config file
-            };
+            Path = Environment.CurrentDirectory,
+            Filter = ConfigFileName,
+            NotifyFilter = NotifyFilters.LastWrite, // only watch for writes to config file
+        };
 
-            fileWatcher.Changed += onConfigChanged; // add event handler
+        fileWatcher.Changed += onConfigChanged; // add event handler
 
-            fileWatcher.EnableRaisingEvents = true; // begin watching
-        }
+        fileWatcher.EnableRaisingEvents = true; // begin watching
     }
 #pragma warning restore CS8618
 
     private static void onConfigChanged(object sender, FileSystemEventArgs e)
     {
-        Debug.Assert(e.Name == ConfigFileName);
-        Logger.Info("Configuration file modified, reloading config...", LogArea.Config);
-        Logger.Warn("Some changes may not apply; they will require a restart of Lighthouse.", LogArea.Config);
-
-        ServerConfiguration? configuration = fromFile(ConfigFileName);
-        if (configuration == null)
+        try
         {
-            Logger.Warn("The new configuration was unable to be loaded for some reason. The old config has been kept.", LogArea.Config);
-            return;
+            fileWatcher.EnableRaisingEvents = false;
+            Debug.Assert(e.Name == ConfigFileName);
+            Logger.Info("Configuration file modified, reloading config...", LogArea.Config);
+            Logger.Warn("Some changes may not apply; they will require a restart of Lighthouse.", LogArea.Config);
+
+            ServerConfiguration? configuration = fromFile(ConfigFileName);
+            if (configuration == null)
+            {
+                Logger.Warn(
+                    "The new configuration was unable to be loaded for some reason. The old config has been kept.",
+                    LogArea.Config);
+                return;
+            }
+
+            Instance = configuration;
+
+            Logger.Success("Successfully reloaded the configuration!", LogArea.Config);
         }
-
-        Instance = configuration;
-
-        Logger.Success("Successfully reloaded the configuration!", LogArea.Config);
+        finally
+        {
+            fileWatcher.EnableRaisingEvents = true;
+        }
     }
 
     private static INamingConvention namingConvention = CamelCaseNamingConvention.Instance;
 
     private static ServerConfiguration? fromFile(string path)
     {
-        IDeserializer deserializer = new DeserializerBuilder().WithNamingConvention(namingConvention).Build();
+        IDeserializer deserializer = new DeserializerBuilder().WithNamingConvention(namingConvention).IgnoreUnmatchedProperties().Build();
 
         string text;
 
@@ -162,12 +171,6 @@ public class ServerConfiguration
     }
 
     #endregion
-
-    // TODO: Find a way to properly remove config options
-    // YamlDotNet hates that and it's fucking annoying.
-    // This seriously sucks. /rant
-    [Obsolete("Obsolete. Use the Website/GameApi/Api listen URLS instead.")]
-    public string ListenUrl { get; set; } = "http://localhost:10060";
 
     public string WebsiteListenUrl { get; set; } = "http://localhost:10060";
     public string GameApiListenUrl { get; set; } = "http://localhost:10061";
@@ -197,4 +200,5 @@ public class ServerConfiguration
     public UserGeneratedContentLimitConfiguration UserGeneratedContentLimits { get; set; } = new();
     public WebsiteConfiguration WebsiteConfiguration { get; set; } = new();
     public CustomizationConfiguration Customization { get; set; } = new();
+    public RateLimitConfiguration RateLimitConfiguration { get; set; } = new();
 }

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -127,9 +127,7 @@ public class ServerConfiguration
             ServerConfiguration? configuration = fromFile(ConfigFileName);
             if (configuration == null)
             {
-                Logger.Warn(
-                    "The new configuration was unable to be loaded for some reason. The old config has been kept.",
-                    LogArea.Config);
+                Logger.Warn("The new configuration was unable to be loaded for some reason. The old config has been kept.", LogArea.Config);
                 return;
             }
 

--- a/ProjectLighthouse/Files/FileHelper.cs
+++ b/ProjectLighthouse/Files/FileHelper.cs
@@ -227,6 +227,15 @@ public static class FileHelper
 
     public static bool ResourceExists(string hash) => File.Exists(GetResourcePath(hash));
 
+    public static void DeleteResource(string hash)
+    {
+        // sanity check so someone doesn't somehow delete the entire resource folder
+        if (ResourceExists(hash) && (File.GetAttributes(hash) & FileAttributes.Directory) != FileAttributes.Directory)
+        {
+            File.Delete(GetResourcePath(hash));
+        }
+    }
+
     public static int ResourceSize(string hash)
     {
         try

--- a/ProjectLighthouse/Logging/LogArea.cs
+++ b/ProjectLighthouse/Logging/LogArea.cs
@@ -24,4 +24,5 @@ public enum LogArea
     Publish,
     Maintenance,
     Score,
+    RateLimit,
 }

--- a/ProjectLighthouse/Middlewares/RateLimitMiddleware.cs
+++ b/ProjectLighthouse/Middlewares/RateLimitMiddleware.cs
@@ -21,19 +21,6 @@ public class RateLimitMiddleware : MiddlewareDBContext
     public RateLimitMiddleware(RequestDelegate next) : base(next)
     { }
 
-    /*
-     * What needs to be done:
-     * Get the ip address from the request
-     * Check if the user has already sent too many requests in which case we return code 429
-     * Possible check if the ip is from cloudflare (maybe someone configured their shit wrong)
-     * add the request to recentRequests
-     * Possibly check the response code of the request that it handles to only add if it was a 200?
-     *
-     * MAJOR TODOs : add a section to the config where people can add general rate limit rules and custom rules for certain endpoints 
-     *             : handle custom config rules here
-     *             : while I'm here doing middleware shit, migrate GameServerStartup app.Use to middleware classes
-     */
-
     public override async Task InvokeAsync(HttpContext ctx, Database database)
     {
         // We only want to rate limit POST requests
@@ -49,7 +36,9 @@ public class RateLimitMiddleware : MiddlewareDBContext
             return;
         }
 
-        RateLimitOptions? rateLimitOptions = GetRateLimitOverride(ctx.Request.Path);
+        PathString path = RemoveTrailingSlash(ctx.Request.Path.ToString());
+
+        RateLimitOptions? rateLimitOptions = GetRateLimitOverride(path);
 
         if (!IsRateLimitEnabled(rateLimitOptions))
         {
@@ -57,19 +46,16 @@ public class RateLimitMiddleware : MiddlewareDBContext
             return;
         }
 
-        RemoveExpiredEntries(rateLimitOptions);
+        RemoveExpiredEntries();
 
-        Console.WriteLine(
-            $@"[DEBUG]: path={ctx.Request.Path} ipAddress={address}, numRequestsForPath={GetNumRequestsForPath(address, ctx.Request.Path)+1}");
-
-        if (GetNumRequestsForPath(address, ctx.Request.Path) + 1 >= GetMaxNumRequests(rateLimitOptions))
+        if (GetNumRequestsForPath(address, path) + 1 >= GetMaxNumRequests(rateLimitOptions))
         {
-            Console.WriteLine(@$"[DEBUG]: Next request expires in {recentRequests[address][0].Timestamp + GetRequestInterval(rateLimitOptions) * 1000 - TimeHelper.TimestampMillis}");
+            ctx.Response.Headers.Add("Retry-After", "" + Math.Ceiling((recentRequests[address][0].Expiration - TimeHelper.TimestampMillis) / 1000f));
             ctx.Response.StatusCode = 429;
             return;
         }
 
-        LogRequest(address, ctx.Request.Path);
+        LogRequest(address, path, rateLimitOptions);
 
         // Handle request as normal
         await this.next(ctx);
@@ -79,29 +65,50 @@ public class RateLimitMiddleware : MiddlewareDBContext
 
     public static bool IsRateLimitEnabled(RateLimitOptions? rateLimitOverride) => rateLimitOverride?.Enabled ?? ServerConfiguration.Instance.RateLimitConfiguration.GlobalOptions.Enabled;
 
-    private static long GetRequestInterval(RateLimitOptions? rateLimitOverride) => rateLimitOverride?.RequestsPerInterval ?? ServerConfiguration.Instance.RateLimitConfiguration.GlobalOptions.RequestInterval;
+    private static long GetRequestInterval(RateLimitOptions? rateLimitOverride) => rateLimitOverride?.RequestInterval ?? ServerConfiguration.Instance.RateLimitConfiguration.GlobalOptions.RequestInterval;
 
     private static RateLimitOptions? GetRateLimitOverride(PathString path)
     {
         Dictionary<string, RateLimitOptions> overrides = ServerConfiguration.Instance.RateLimitConfiguration.RateLimitOverrides;
-        return overrides.Keys.Where(s => new Regex(s.Replace("/", @"\/").Replace("*", ".*")).Match(path).Success).Select(s => overrides[s]).FirstOrDefault();
+        List<string> matchingOptions = overrides.Keys.Where(s => new Regex("^" + RemoveTrailingSlash(s).Replace("/", @"\/").Replace("*", ".*") + "$").Match(path).Success).ToList();
+        if (matchingOptions.Count == 0) return null;
+        // return 0 for equal, -1 for a, and 1 for b
+        matchingOptions.Sort((a, b) =>
+        {
+            int aWeight = 100;
+            int bWeight = 100;
+            if (a.Contains('*')) aWeight -= 20;
+            if (b.Contains('*')) bWeight -= 20;
+
+            aWeight += a.Length;
+            bWeight += b.Length;
+
+            if (aWeight > bWeight) return -1;
+
+            if (bWeight > aWeight) return 1;
+
+            return 0;
+        });
+        return overrides[matchingOptions.First()];
     }
 
-    private static void LogRequest(IPAddress address, PathString path)
+    private static void LogRequest(IPAddress address, PathString path, RateLimitOptions? options)
     {
-        recentRequests.GetOrAdd(address, new List<LighthouseRequest>()).Add(LighthouseRequest.Create(path));
+        recentRequests.GetOrAdd(address, new List<LighthouseRequest>()).Add(LighthouseRequest.Create(path, GetRequestInterval(options) * 1000 + TimeHelper.TimestampMillis));
     }
 
-    private static void RemoveExpiredEntries(RateLimitOptions? rateLimitOverride)
+    private static void RemoveExpiredEntries()
     {
         for (int i = recentRequests.Count - 1; i >= 0; i--)
         {
             IPAddress address = recentRequests.ElementAt(i).Key;
-            recentRequests[address].RemoveAll(r => TimeHelper.TimestampMillis > r.Timestamp + GetRequestInterval(GetRateLimitOverride(r.Path)));
+            recentRequests[address].RemoveAll(r => TimeHelper.TimestampMillis > r.Expiration);
             // Remove empty entries
             if (recentRequests[address].Count == 0) recentRequests.TryRemove(address, out _);
         }
     }
+
+    private static string RemoveTrailingSlash(string s) => s.TrimEnd('/').TrimEnd('\\');
 
     private static int GetNumRequestsForPath(IPAddress address, PathString pathString)
     {
@@ -114,14 +121,14 @@ public class RateLimitMiddleware : MiddlewareDBContext
     private class LighthouseRequest
     {
         public PathString Path { get; private init; } = "";
-        public long Timestamp { get; private init; }
+        public long Expiration { get; private init; }
 
-        public static LighthouseRequest Create(PathString path)
+        public static LighthouseRequest Create(PathString path, long expiration)
         {
             LighthouseRequest request = new()
             {
                 Path = path,
-                Timestamp = TimeHelper.TimestampMillis,
+                Expiration = expiration,
             };
             return request;
         }

--- a/ProjectLighthouse/Middlewares/RateLimitMiddleware.cs
+++ b/ProjectLighthouse/Middlewares/RateLimitMiddleware.cs
@@ -1,0 +1,122 @@
+﻿#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Helpers;
+using Microsoft.AspNetCore.Http;
+
+namespace LBPUnion.ProjectLighthouse.Middlewares;
+
+public class RateLimitMiddleware : MiddlewareDBContext
+{
+
+    // (userId, requestData)
+    private static readonly ConcurrentDictionary<IPAddress, List<LighthouseRequest>> recentRequests = new();
+
+    public RateLimitMiddleware(RequestDelegate next) : base(next)
+    { }
+
+    /*
+     * What needs to be done:
+     * Get the ip address from the request
+     * Check if the user has already sent too many requests in which case we return code 429
+     * Possible check if the ip is from cloudflare (maybe someone configured their shit wrong)
+     * add the request to recentRequests
+     * Possibly check the response code of the request that it handles to only add if it was a 200?
+     *
+     * MAJOR TODOs : add a section to the config where people can add general rate limit rules and custom rules for certain endpoints 
+     *             : handle custom config rules here
+     *             : while I'm here doing middleware shit, migrate GameServerStartup app.Use to middleware classes
+     */
+
+    public override async Task InvokeAsync(HttpContext ctx, Database database)
+    {
+        // We only want to rate limit POST requests
+        if (ctx.Request.Method != "POST")
+        {
+            await this.next(ctx);
+            return;
+        }
+        IPAddress? address = ctx.Connection.RemoteIpAddress;
+        if (address == null)
+        {
+            await this.next(ctx);
+            return;
+        }
+
+        RateLimitOverride? rateLimit = GetRateLimitOverride(ctx.Request.Path);
+
+        RemoveExpiredEntries(rateLimit);
+
+        Console.WriteLine(
+            $@"[DEBUG]: path={ctx.Request.Path} ipAddress={address}, numRequestsForPath={GetNumRequestsForPath(address, ctx.Request.Path)+1}");
+
+        if (GetNumRequestsForPath(address, ctx.Request.Path) + 1 >= GetMaxNumRequests(rateLimit))
+        {
+            Console.WriteLine(@$"[DEBUG]: Next request expires in {recentRequests[address][0].Timestamp + GetRequestInterval(ctx.Request.Path, rateLimit) * 1000 - TimeHelper.TimestampMillis}");
+            ctx.Response.StatusCode = 429;
+            return;
+        }
+
+        LogRequest(address, ctx.Request.Path);
+
+        // Handle request as normal
+        await this.next(ctx);
+    }
+
+    private static int GetMaxNumRequests(RateLimitOverride? rateLimitOverride) => rateLimitOverride?.RequestsPerInterval ?? ServerConfiguration.Instance.RateLimitConfiguration.RequestsPerInterval;
+
+    private static long GetRequestInterval(PathString path, RateLimitOverride? rateLimitOverride) => rateLimitOverride?.RequestsPerInterval ?? ServerConfiguration.Instance.RateLimitConfiguration.RequestInterval;
+
+    private static RateLimitOverride? GetRateLimitOverride(PathString path)
+    {
+        Dictionary<string, RateLimitOverride> overrides = ServerConfiguration.Instance.RateLimitConfiguration.RateLimitOverrides;
+        return overrides.Keys.Where(s => new Regex(s.Replace("/", @"\/").Replace("*", ".*")).Match(path).Success).Select(s => overrides[s]).FirstOrDefault();
+    }
+
+    private static void LogRequest(IPAddress address, PathString path)
+    {
+        recentRequests.GetOrAdd(address, new List<LighthouseRequest>()).Add(LighthouseRequest.Create(path));
+    }
+
+    private static void RemoveExpiredEntries(RateLimitOverride? rateLimitOverride)
+    {
+        for (int i = recentRequests.Count - 1; i >= 0; i--)
+        {
+            IPAddress address = recentRequests.ElementAt(i).Key;
+            recentRequests[address].RemoveAll(r => TimeHelper.TimestampMillis > r.Timestamp + GetRequestInterval(r.Path, rateLimitOverride));
+            // Remove empty entries
+            if (recentRequests[address].Count == 0) recentRequests.TryRemove(address, out _);
+        }
+    }
+
+    private static int GetNumRequestsForPath(IPAddress address, PathString pathString)
+    {
+        if (!recentRequests.ContainsKey(address)) return 0;
+
+        List<LighthouseRequest> requests = recentRequests[address];
+        return requests.Count(r => r.Path == pathString);
+    }
+
+    private class LighthouseRequest
+    {
+        public PathString Path { get; private init; } = "";
+        public long Timestamp { get; private init; }
+
+        public static LighthouseRequest Create(PathString path)
+        {
+            LighthouseRequest request = new()
+            {
+                Path = path,
+                Timestamp = TimeHelper.TimestampMillis,
+            };
+            return request;
+        }
+    }
+    
+}

--- a/ProjectLighthouse/ProjectLighthouse.csproj
+++ b/ProjectLighthouse/ProjectLighthouse.csproj
@@ -10,8 +10,8 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-        <PackageReference Include="Pfim" Version="0.11.1"/>
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3"/>
+        <PackageReference Include="Pfim" Version="0.11.1" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
         <PackageReference Include="Discord.Net.Webhook" Version="3.8.1" />
         <PackageReference Include="InfluxDB.Client" Version="4.5.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />


### PR DESCRIPTION
This pull request adds rate limiting to the website and game server. The API server was intentionally left out since there aren't really any public-facing POST endpoints. These rate limit options can be configured to have custom parameters for specific URLs or more generalized URLs with the use of wildcards (*). The GameServerStartup class has also been refactored to move the digest header check and the last contact update to separate middleware classes.

* Fixes a bug in LBP3 where if you republish a level from an earlier game the client tries to forcefully update the level to LBP3.
* Made the verification email log not send more than 1 email every 30 seconds.
* Reverted the change that made the verification email page reuse tokens. It will now regenerate the token and delete any existing tokens.
* Fixed the configuration system so that entries can be removed with new config versions
* Fixed a bug with config reloading where the onConfigChanged would be called twice.

Closes #186, Closes #486
