### PR TITLE
Fix #545 - test for img size & 1:1 ratio

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -143,7 +143,7 @@ function onSubmit(e){
       const file = e.target.files.item(0);
       const img = System.Drawing.Image.FromFile(file);
       const minSize = 1;
-      const maxSize = 1024;
+      const maxSize = 512;
       if (file.type !== "image/jpeg" && file.type !== "image/png")
           return;
       if (!(img.Height <= maxSize && img.Height >= minSize) && (img.Width !== img.Height))

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -141,14 +141,12 @@ function onSubmit(e){
     let selectedAvatar = "";
     document.getElementById("avatar").addEventListener("change", e => {
       const file = e.target.files.item(0);
-      Image img = System.Drawing.Image.FromFile(file);
-      int width = img.Width;
-      int height = img.Height;
-      int minSize = 1;
-      int maxSize = 1024;
+      const img = System.Drawing.Image.FromFile(file);
+      const minSize = 1;
+      const maxSize = 1024;
       if (file.type !== "image/jpeg" && file.type !== "image/png")
           return;
-      if (!(height <= maxSize && height >= minSize) && (width !== height))
+      if (!(img.Height <= maxSize && img.Height >= minSize) && (img.Width !== img.Height))
           return;
       
       const output = document.getElementById('userPicture');

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -1,6 +1,7 @@
 ﻿@page "/user/{userId:int}/settings"
 @using System.Globalization
 @using System.Web
+@using System.Drawing
 @using LBPUnion.ProjectLighthouse.Configuration
 @using LBPUnion.ProjectLighthouse.Extensions
 @using LBPUnion.ProjectLighthouse.Localization
@@ -140,7 +141,14 @@ function onSubmit(e){
     let selectedAvatar = "";
     document.getElementById("avatar").addEventListener("change", e => {
       const file = e.target.files.item(0);
+      Image img = System.Drawing.Image.FromFile(file);
+      int width = img.Width;
+      int height = img.Height;
+      int minSize = 1;
+      int maxSize = 1024;
       if (file.type !== "image/jpeg" && file.type !== "image/png")
+          return;
+      if (!(height <= maxSize && height >= minSize) && (width !== height))
           return;
       
       const output = document.getElementById('userPicture');


### PR DESCRIPTION
This is completely untested because I don't have an environment set up to test this with. Just a super quick and dirty fix. Could also be adjusted to, instead of checking dimensions, check actual file size using HttpPostedFileBase.ContentLength