### PR TITLE
Make chat filter logging configurable

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -120,7 +120,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
 
         string username = await this.database.UsernameFromGameToken(token);
 
-        Logger.Info($"{username}: {message} / {scannedText}", LogArea.Filter);
+        if (ServerConfiguration.Instance.LogChatFiltering) Logger.Info($"{username}: {message} / {scannedText}", LogArea.Filter);
 
         return this.Ok(scannedText);
     }

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -185,6 +185,7 @@ public class ServerConfiguration
     public string AnnounceText { get; set; } = "You are now logged in as %user (id: %id).";
 #endif
     public bool CheckForUnsafeFiles { get; set; } = true;
+    public bool LogChatFiltering { get; set; } = false;
 
     public FilterMode UserInputFilterMode { get; set; } = FilterMode.None;
 


### PR DESCRIPTION
Disables chat logging by default, but allows for it to be re-enabled if needed.