### PR TITLE
Make DB migrations use a distributed lock

### DIFF
--- a/ProjectLighthouse/ProjectLighthouse.csproj
+++ b/ProjectLighthouse/ProjectLighthouse.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
         <PackageReference Include="YamlDotNet" Version="12.3.1" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
+        <PackageReference Include="DistributedLock.MySql" Version="1.0.1"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse/StartupTasks.cs
+++ b/ProjectLighthouse/StartupTasks.cs
@@ -162,10 +162,8 @@ public static class StartupTasks
         Stopwatch stopwatch = Stopwatch.StartNew();
         Logger.Info("Migrating database...", LogArea.Database);
         MySqlDistributedLock mutex = new("LighthouseMigration", ServerConfiguration.Instance.DbConnectionString);
-        Logger.Info("Before mutex.AcquireAsync()", LogArea.Database);
         await using (await mutex.AcquireAsync())
         {
-            Logger.Info("After mutex.AcquireAsync()", LogArea.Database);
             stopwatch.Stop();
             Logger.Success($"Acquiring migration lock took {stopwatch.ElapsedMilliseconds}ms", LogArea.Database);
 

--- a/ProjectLighthouse/StartupTasks.cs
+++ b/ProjectLighthouse/StartupTasks.cs
@@ -159,7 +159,7 @@ public static class StartupTasks
         Stopwatch totalStopwatch = Stopwatch.StartNew();
         Stopwatch stopwatch = Stopwatch.StartNew();
         Logger.Info("Migrating database...", LogArea.Database);
-        using Mutex mutex = new(false, "Global\\LighthouseDatabaseMigration", out bool createdNew);
+        Mutex mutex = new(false, "Global\\LighthouseDatabaseMigration", out bool createdNew);
         Logger.Info($"Initialized mutex, createdNew={createdNew}", LogArea.Database);
         try
         {
@@ -198,6 +198,8 @@ public static class StartupTasks
             Logger.Info("About to release mutex", LogArea.Database);
             mutex.ReleaseMutex();
             Logger.Info("Released mutex", LogArea.Database);
+            mutex.Dispose();
+            Logger.Info("Disposed mutex", LogArea.Database);
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,9 @@ services:
       MARIADB_DATABASE: lighthouse
     healthcheck:
       test: "/usr/bin/mysql --user=root --password=lighthouse --execute \"SHOW DATABASES;\""
-      timeout: 20s
-      retries: 10
+      timeout: 10s
+      interval: 5s
+      retries: 5
     volumes:
       - "database:/var/lib/mysql"
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
         condition: service_started
       redis:
         condition: service_started
-      gameserver:
-        condition: service_healthy
     volumes:
       - "./data:/lighthouse/data:z"
   api:
@@ -61,8 +59,6 @@ services:
         condition: service_started
       redis:
         condition: service_started
-      gameserver:
-        condition: service_healthy
     volumes:
       - "./data:/lighthouse/data:z"
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         condition: service_started
     volumes:
       - "./data:/lighthouse/data:z"
+      - "./data/.aspnet:/lighthouse/.aspnet:z"
   website:
     image: lighthouse:latest
     container_name: website
@@ -37,11 +38,12 @@ services:
       retries: 5
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_started
     volumes:
       - "./data:/lighthouse/data:z"
+      - "./data/.aspnet:/lighthouse/.aspnet:z"
   api:
     image: lighthouse:latest
     container_name: api
@@ -56,11 +58,12 @@ services:
       retries: 5
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       redis:
         condition: service_started
     volumes:
       - "./data:/lighthouse/data:z"
+      - "./data/.aspnet:/lighthouse/.aspnet:z"
   db:
     image: mariadb
     container_name: db


### PR DESCRIPTION
This PR removes the hard dependency on the game server for migrations. Currently, if you run in Release mode, migrations will only be run if the server type is GameServer. The new functionality is that any server can run a migration, and access is controlled by a distributed lock that lives in the SQL server.  This prevents two servers from attempting to perform a migration simultaneously, which would leave the database in a potentially broken state.

Also changes docker-compose to store the asp.net data protection keys outside of the container.