### PR TITLE
Link to reviewer in card and pad labels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    Project Lighthouse
+    Copyright (C) 2023  LBP Union
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by

--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Project Lighthouse
-    Copyright (C) 2023  LBP Union
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C)  <year> <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by

--- a/LICENSE
+++ b/LICENSE
@@ -630,7 +630,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C)  <year> <name of author>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
@@ -60,7 +60,9 @@
                         <img class="cardIcon slotCardIcon" src="@ServerConfiguration.Instance.ExternalUrl/gameAssets/@faceHash" alt="@faceAlt" title="@faceAlt" style="min-width: @(size)px; width: @(size)px; height: @(size)px">
                     </div>
                     <div class="cardStats">
-                        <h3 style="margin-bottom: 5px;">@review.Reviewer?.Username</h3>
+                        <a href="/user/@review.Reviewer?.UserId">
+                            <h3 style="margin-bottom: 5px;">@review.Reviewer?.Username</h3>
+                        </a>
                         @if (review.Deleted)
                         {
                             if (review.DeletedBy == DeletedBy.LevelAuthor)
@@ -80,10 +82,12 @@
                         {
                             @if (review.Labels.Length > 1)
                             {
-                                @foreach (string reviewLabel in review.Labels)
-                                {
-                                    <div class="ui blue label">@LabelHelper.TranslateTag(reviewLabel)</div>
-                                }
+                                <div style="padding-bottom: 5px;">
+                                    @foreach (string reviewLabel in review.Labels)
+                                    {
+                                        <div class="ui blue label">@LabelHelper.TranslateTag(reviewLabel)</div>
+                                    }
+                                </div>
                             }
                             @if (string.IsNullOrWhiteSpace(review.Text))
                             {


### PR DESCRIPTION
Visual changes to add link to reviewer's profile in review card, as well as wrapping the labels in a `div` and padding them for organization.

<img width="523" alt="Screen Shot 2023-02-06 at 9 52 22 AM" src="https://user-images.githubusercontent.com/68549366/217004193-0aed88d3-2856-4a50-92a2-71cf71cffa43.png">
<img width="733" alt="Screen Shot 2023-02-06 at 9 53 36 AM" src="https://user-images.githubusercontent.com/68549366/217004511-a3fa05c7-0a9a-44a6-a489-7788232adc9f.png">