### PR TITLE
Allow environment variable expansion in config files

### DIFF
--- a/ProjectLighthouse/Configuration/ConfigurationBase.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationBase.cs
@@ -165,7 +165,11 @@ public abstract class ConfigurationBase<T> where T : class, new()
                 continue;
             }
 
+            // Expand environment variables in strings. Format is windows-like (%ENV_NAME%)
+            if (propertyInfo.PropertyType == typeof(string)) value = Environment.ExpandEnvironmentVariables((string)value);
+
             local.SetValue(this, value);
+
         }
     }
 

--- a/ProjectLighthouse/Configuration/ConfigurationBase.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationBase.cs
@@ -169,7 +169,6 @@ public abstract class ConfigurationBase<T> where T : class, new()
             if (propertyInfo.PropertyType == typeof(string)) value = Environment.ExpandEnvironmentVariables((string)value);
 
             local.SetValue(this, value);
-
         }
     }
 


### PR DESCRIPTION
Now you can use environment variables in string variables for any config. The format is similar to windows because of how C# implements it. If you had a variable named `DB_ADDRESS` you would access it with `%DB_ADDRESS%`. I'm contemplating changing the default config values to include environment variables for easy setup on docker but I think that's outside the scope of this PR.