### PR TITLE
StasticsHelper + Community Tab Performance Fix

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -280,7 +280,7 @@ public class SlotsController : ControllerBase
             .Take(Math.Min(pageSize, 30));
         string response = Enumerable.Aggregate(slots, string.Empty, (current, slot) => current + slot.Serialize(gameVersion));
         int start = pageStart + Math.Min(pageSize, ServerConfiguration.Instance.UserGeneratedContentLimits.EntitledSlots);
-        int total = await StatisticsHelper.TeamPickCountForGame(this.database, token);
+        int total = await StatisticsHelper.TeamPickCountForGame(this.database, token.GameVersion);
 
         return this.Ok(generateSlotsResponse(response, start, total));
     }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -280,7 +280,7 @@ public class SlotsController : ControllerBase
             .Take(Math.Min(pageSize, 30));
         string response = Enumerable.Aggregate(slots, string.Empty, (current, slot) => current + slot.Serialize(gameVersion));
         int start = pageStart + Math.Min(pageSize, ServerConfiguration.Instance.UserGeneratedContentLimits.EntitledSlots);
-        int total = await StatisticsHelper.TeamPickCountForGame(this.database, this.GetToken().GameVersion);
+        int total = await StatisticsHelper.TeamPickCountForGame(this.database, token);
 
         return this.Ok(generateSlotsResponse(response, start, total));
     }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -280,7 +280,7 @@ public class SlotsController : ControllerBase
             .Take(Math.Min(pageSize, 30));
         string response = Enumerable.Aggregate(slots, string.Empty, (current, slot) => current + slot.Serialize(gameVersion));
         int start = pageStart + Math.Min(pageSize, ServerConfiguration.Instance.UserGeneratedContentLimits.EntitledSlots);
-        int total = await StatisticsHelper.TeamPickCount(this.database);
+        int total = await StatisticsHelper.TeamPickCountForGame(this.database, this.GetToken().GameVersion);
 
         return this.Ok(generateSlotsResponse(response, start, total));
     }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
@@ -22,6 +22,8 @@ public class StatisticsController : ControllerBase
     }
 
     [HttpGet("playersInPodCount")]
+    public IActionResult PlayersInPodCount() => this.Ok((StatisticsHelper.UserCountInPod(this.database)).ToString());
+
     [HttpGet("totalPlayerCount")]
     public async Task<IActionResult> TotalPlayerCount() => this.Ok((await StatisticsHelper.RecentMatchesForGame(this.database, this.GetToken().GameVersion)).ToString());
 
@@ -29,7 +31,7 @@ public class StatisticsController : ControllerBase
     public async Task<IActionResult> PlanetStats()
     {
         int totalSlotCount = await StatisticsHelper.SlotCountForGame(this.database, this.GetToken().GameVersion);
-        int mmPicksCount = await StatisticsHelper.TeamPickCount(this.database);
+        int mmPicksCount = await StatisticsHelper.TeamPickCountForGame(this.database, this.GetToken().GameVersion);
 
         return this.Ok
         (

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
@@ -23,7 +23,7 @@ public class StatisticsController : ControllerBase
 
     [HttpGet("playersInPodCount")]
     [HttpGet("totalPlayerCount")]
-    public async Task<IActionResult> TotalPlayerCount() => this.Ok((await StatisticsHelper.RecentMatches(this.database)).ToString());
+    public async Task<IActionResult> TotalPlayerCount() => this.Ok((await StatisticsHelper.RecentMatchesForGame(this.database, this.GetToken().GameVersion)).ToString());
 
     [HttpGet("planetStats")]
     public async Task<IActionResult> PlanetStats()

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/CategoryWithUser.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/CategoryWithUser.cs
@@ -32,8 +32,8 @@ public abstract class CategoryWithUser : Category
         return -1;
     }
 
-    public abstract IEnumerable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize);
-    public override IEnumerable<Slot> GetSlots(DatabaseContext database, int pageStart, int pageSize)
+    public abstract IQueryable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize);
+    public override IList<Slot> GetSlots(DatabaseContext database, int pageStart, int pageSize)
     {
         #if DEBUG
         Logger.Error("tried to get slots without user on CategoryWithUser", LogArea.Category);

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/CustomCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/CustomCategory.cs
@@ -36,7 +36,7 @@ public class CustomCategory : Category
     public sealed override string IconHash { get; set; }
     public sealed override string Endpoint { get; set; }
     public override Slot? GetPreviewSlot(DatabaseContext database) => database.Slots.FirstOrDefault(s => s.SlotId == this.SlotIds[0]);
-    public override IEnumerable<Slot> GetSlots
+    public override IQueryable<Slot> GetSlots
         (DatabaseContext database, int pageStart, int pageSize)
         => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3).Where(s => this.SlotIds.Contains(s.SlotId));
     public override int GetTotalSlots(DatabaseContext database) => this.SlotIds.Count;

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/HeartedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/HeartedCategory.cs
@@ -24,7 +24,7 @@ public class HeartedCategory : CategoryWithUser
             .ByGameVersion(GameVersion.LittleBigPlanet3, false, false, true)
             .FirstOrDefault();
 
-    public override IEnumerable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize)
+    public override IQueryable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize)
         => database.HeartedLevels.Where(h => h.UserId == user.UserId)
             .Where(h => h.Slot.Type == SlotType.User && !h.Slot.Hidden && h.Slot.GameVersion <= GameVersion.LittleBigPlanet3)
             .OrderByDescending(h => h.HeartedLevelId)

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/LuckyDipCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/LuckyDipCategory.cs
@@ -15,7 +15,7 @@ public class LuckyDipCategory : Category
     public override string IconHash { get; set; } = "g820605";
     public override string Endpoint { get; set; } = "lbp2luckydip";
     public override Slot? GetPreviewSlot(DatabaseContext database) => database.Slots.Where(s => s.Type == SlotType.User).OrderByDescending(_ => EF.Functions.Random()).FirstOrDefault();
-    public override IEnumerable<Slot> GetSlots
+    public override IQueryable<Slot> GetSlots
         (DatabaseContext database, int pageStart, int pageSize)
         => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
             .OrderByDescending(_ => EF.Functions.Random())

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/MostPlayedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/MostPlayedCategory.cs
@@ -18,7 +18,7 @@ public class MostPlayedCategory : Category
         .OrderByDescending(s => s.PlaysLBP1Unique + s.PlaysLBP2Unique + s.PlaysLBP3Unique)
         .ThenByDescending(s => s.PlaysLBP1 + s.PlaysLBP2 + s.PlaysLBP3)
         .FirstOrDefault();
-    public override IEnumerable<Slot> GetSlots
+    public override IQueryable<Slot> GetSlots
         (DatabaseContext database, int pageStart, int pageSize)
         => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
             .OrderByDescending(s => s.PlaysLBP1Unique + s.PlaysLBP2Unique + s.PlaysLBP3Unique)

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/NewestLevelsCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/NewestLevelsCategory.cs
@@ -14,7 +14,7 @@ public class NewestLevelsCategory : Category
     public override string IconHash { get; set; } = "g820623";
     public override string Endpoint { get; set; } = "newest";
     public override Slot? GetPreviewSlot(DatabaseContext database) => database.Slots.Where(s => s.Type == SlotType.User).OrderByDescending(s => s.FirstUploaded).FirstOrDefault();
-    public override IEnumerable<Slot> GetSlots
+    public override IQueryable<Slot> GetSlots
         (DatabaseContext database, int pageStart, int pageSize)
         => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
             .OrderByDescending(s => s.FirstUploaded)

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/QueueCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/QueueCategory.cs
@@ -24,7 +24,7 @@ public class QueueCategory : CategoryWithUser
             .ByGameVersion(GameVersion.LittleBigPlanet3, false, false, true)
             .FirstOrDefault();
 
-    public override IEnumerable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize)
+    public override IQueryable<Slot> GetSlots(DatabaseContext database, User user, int pageStart, int pageSize)
         => database.QueuedLevels.Where(q => q.UserId == user.UserId)
             .Where(q => q.Slot.Type == SlotType.User && !q.Slot.Hidden && q.Slot.GameVersion <= GameVersion.LittleBigPlanet3)
             .OrderByDescending(q => q.QueuedLevelId)

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
@@ -14,7 +14,7 @@ public class TeamPicksCategory : Category
     public override string IconHash { get; set; } = "g820626";
     public override string Endpoint { get; set; } = "team_picks";
     public override Slot? GetPreviewSlot(DatabaseContext database) => database.Slots.OrderByDescending(s => s.FirstUploaded).FirstOrDefault(s => s.TeamPick);
-    public override IEnumerable<Slot> GetSlots
+    public override IQueryable<Slot> GetSlots
         (DatabaseContext database, int pageStart, int pageSize)
         => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
             .OrderByDescending(s => s.FirstUploaded)

--- a/ProjectLighthouse/Helpers/StatisticsHelper.cs
+++ b/ProjectLighthouse/Helpers/StatisticsHelper.cs
@@ -27,7 +27,7 @@ public static class StatisticsHelper
 
     public static async Task<int> TeamPickCount(DatabaseContext database) => await database.Slots.CountAsync(s => s.TeamPick);
 
-     public static async Task<int> TeamPickCountForGame(DatabaseContext database, GameVersion gameVersion, bool includeSublevels = false) => await database.Slots.ByGameVersion(gameVersion, includeSublevels).CountAsync(s => s.TeamPickForGame);
+     public static async Task<int> TeamPickCountForGame(DatabaseContext database, GameVersion gameVersion) => await database.Slots.ByGameVersion(gameVersion).CountAsync(s => s.TeamPick);
 
     public static async Task<int> PhotoCount(DatabaseContext database) => await database.Photos.CountAsync();
     

--- a/ProjectLighthouse/Helpers/StatisticsHelper.cs
+++ b/ProjectLighthouse/Helpers/StatisticsHelper.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Types.Levels;
+using LBPUnion.ProjectLighthouse.Types.Matchmaking.Rooms;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,7 +23,11 @@ public static class StatisticsHelper
 
     public static async Task<int> UserCount(DatabaseContext database) => await database.Users.CountAsync(u => u.PermissionLevel != PermissionLevel.Banned);
 
+    public static int UserCountInPod(DatabaseContext database) => RoomHelper.Rooms.Count(r => r.State == RoomState.Idle);
+
     public static async Task<int> TeamPickCount(DatabaseContext database) => await database.Slots.CountAsync(s => s.TeamPick);
+
+     public static async Task<int> TeamPickCountForGame(DatabaseContext database, GameVersion gameVersion, bool includeSublevels = false) => await database.Slots.ByGameVersion(gameVersion, includeSublevels).CountAsync(s => s.TeamPickForGame);
 
     public static async Task<int> PhotoCount(DatabaseContext database) => await database.Photos.CountAsync();
     

--- a/ProjectLighthouse/Helpers/StatisticsHelper.cs
+++ b/ProjectLighthouse/Helpers/StatisticsHelper.cs
@@ -27,7 +27,7 @@ public static class StatisticsHelper
 
     public static async Task<int> TeamPickCount(DatabaseContext database) => await database.Slots.CountAsync(s => s.TeamPick);
 
-     public static async Task<int> TeamPickCountForGame(DatabaseContext database, GameVersion gameVersion) => await database.Slots.ByGameVersion(gameVersion).CountAsync(s => s.TeamPick);
+    public static async Task<int> TeamPickCountForGame(DatabaseContext database, GameVersion gameVersion) => await database.Slots.ByGameVersion(gameVersion).CountAsync(s => s.TeamPick);
 
     public static async Task<int> PhotoCount(DatabaseContext database) => await database.Photos.CountAsync();
     

--- a/ProjectLighthouse/Types/Entities/Level/Slot.cs
+++ b/ProjectLighthouse/Types/Entities/Level/Slot.cs
@@ -163,7 +163,6 @@ public class Slot
 
     [XmlIgnore]
     public bool TeamPick { get; set; }
-    
     [XmlIgnore]
     public GameVersion GameVersion { get; set; }
 

--- a/ProjectLighthouse/Types/Entities/Level/Slot.cs
+++ b/ProjectLighthouse/Types/Entities/Level/Slot.cs
@@ -165,9 +165,6 @@ public class Slot
     public bool TeamPick { get; set; }
     
     [XmlIgnore]
-    public bool TeamPickForGame { get; set; }
-
-    [XmlIgnore]
     public GameVersion GameVersion { get; set; }
 
     [XmlIgnore]

--- a/ProjectLighthouse/Types/Entities/Level/Slot.cs
+++ b/ProjectLighthouse/Types/Entities/Level/Slot.cs
@@ -163,6 +163,9 @@ public class Slot
 
     [XmlIgnore]
     public bool TeamPick { get; set; }
+    
+    [XmlIgnore]
+    public bool TeamPickForGame { get; set; }
 
     [XmlIgnore]
     public GameVersion GameVersion { get; set; }


### PR DESCRIPTION
Hello! It's been a while since my last PR, I've been working on these fixes for a while as I was to lazy up until recently to actually fix these issues. The entire changelog is listed below!

- Total players online now show the exact amount of users playing said game, lets say there's 25 people online total, there's 5 playing LBP1, 10 playing LBP2, 5 playing Vita, and 5 playing LBP3. The game show you the amount of players playing the game you're currently on. So for LBP1 it'll show 5 total players online and so on!

- Team Picks total count now show the correct amount of levels that are able to be played on said game. I did a similar update to the total level count a while back as a test and seems to be working great! This update is similar, but it only affects the Team Pick total slot counts for game, this is very useful for vita players that want to actually see the amount of Team Picks that are on their server instance.

- Players in pod count, before when hovering over dive in it would show the total players online. Now it should display the amount of users that you're able to dive into, unfortunately I don't really know of a way to differentiate between PSN and RPCN users. If i do eventually find out I'll submit another PR fixing that issue!

- LBP3 Community Tab Performance Update, Yup, the LBP3 Community Tab should now be much smoother than before due to the "IEnumerable"'s changed to "IQueryable" Thanks to @sudokoko for this fix!

Special thanks to @Slendy, @daggintosh, & @sudokoko for making this all possible.