### PR TITLE
Add translation keys to community categories

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/HeartedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/HeartedCategory.cs
@@ -11,7 +11,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class HeartedCategory : CategoryWithUser
 {
-    public override string Name { get; set; } = "My Hearted Content";
+    public override string Name { get; set; } = "1092830675";
     public override string Description { get; set; } = "Content you've hearted";
     public override string IconHash { get; set; } = "g820611";
     public override string Endpoint { get; set; } = "hearted";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/HighestRatedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/HighestRatedCategory.cs
@@ -10,7 +10,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class HighestRatedCategory : Category
 {
-    public override string Name { get; set; } = "Highest Rated";
+    public override string Name { get; set; } = "3411227110";
     public override string Description { get; set; } = "Community Highest Rated content";
     public override string IconHash { get; set; } = "g820603";
     public override string Endpoint { get; set; } = "thumbs";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/LuckyDipCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/LuckyDipCategory.cs
@@ -10,7 +10,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class LuckyDipCategory : Category
 {
-    public override string Name { get; set; } = "Lucky Dip";
+    public override string Name { get; set; } = "966139835";
     public override string Description { get; set; } = "Randomized uploaded content";
     public override string IconHash { get; set; } = "g820605";
     public override string Endpoint { get; set; } = "lbp2luckydip";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
@@ -10,7 +10,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class MostHeartedCategory : Category
 {
-    public override string Name { get; set; } = "Most Hearted";
+    public override string Name { get; set; } = "2835872044";
     public override string Description { get; set; } = "The Most Hearted Content";
     public override string IconHash { get; set; } = "g820607";
     public override string Endpoint { get; set; } = "mostHearted";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/MostPlayedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/MostPlayedCategory.cs
@@ -9,7 +9,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class MostPlayedCategory : Category
 {
-    public override string Name { get; set; } = "Most Played";
+    public override string Name { get; set; } = "1290380954";
     public override string Description { get; set; } = "The most played content";
     public override string IconHash { get; set; } = "g820608";
     public override string Endpoint { get; set; } = "mostUniquePlays";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/NewestLevelsCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/NewestLevelsCategory.cs
@@ -9,7 +9,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class NewestLevelsCategory : Category
 {
-    public override string Name { get; set; } = "Newest Levels";
+    public override string Name { get; set; } = "877177920";
     public override string Description { get; set; } = "The most recently published content";
     public override string IconHash { get; set; } = "g820623";
     public override string Endpoint { get; set; } = "newest";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/QueueCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/QueueCategory.cs
@@ -11,7 +11,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class QueueCategory : CategoryWithUser
 {
-    public override string Name { get; set; } = "My Queue";
+    public override string Name { get; set; } = "2170169607";
     public override string Description { get; set; } = "Your queued content";
     public override string IconHash { get; set; } = "g820614";
     public override string Endpoint { get; set; } = "queue";

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
@@ -9,7 +9,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
 public class TeamPicksCategory : Category
 {
-    public override string Name { get; set; } = "Team Picks";
+    public override string Name { get; set; } = "1369597325";
     public override string Description { get; set; } = "Community Team Picks";
     public override string IconHash { get; set; } = "g820626";
     public override string Endpoint { get; set; } = "team_picks";


### PR DESCRIPTION
Adds the translation keys for Community Tab categories, as found in #715.
Needs testing, therefore opening as a draft.