### PR TITLE
Allow head requests to status endpoints

### DIFF
--- a/ProjectLighthouse.Servers.API/Controllers/StatusController.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/StatusController.cs
@@ -7,6 +7,6 @@ namespace LBPUnion.ProjectLighthouse.Servers.API.Controllers;
 [Produces("application/json")]
 public class StatusController : ControllerBase
 {
-    [HttpGet("status")]
+    [AcceptVerbs("GET", "HEAD", Route = "status")]
     public IActionResult GetStatus() => this.Ok();
 }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StatusController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StatusController.cs
@@ -7,6 +7,6 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 [Produces("application/json")]
 public class StatusController : ControllerBase
 {
-    [HttpGet("status")]
+    [AcceptVerbs("GET", "HEAD", Route = "status")]
     public IActionResult GetStatus() => this.Ok();
 }

--- a/ProjectLighthouse.Servers.Website/Controllers/StatusController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/StatusController.cs
@@ -7,6 +7,6 @@ namespace LBPUnion.ProjectLighthouse.Servers.Website.Controllers;
 [Produces("application/json")]
 public class StatusController : ControllerBase
 {
-    [HttpGet("status")]
+    [AcceptVerbs("GET", "HEAD", Route = "status")]
     public IActionResult GetStatus() => this.Ok();
 }


### PR DESCRIPTION
Currently trying to send an HTTP HEAD request to any of the status endpoints you get a 405 Method not allowed. Some automated status checks use this method because it's lightweight and doesn't return a body and may interpret the 405 response as an error.