### PR TITLE
Add comment form max char limit validation

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -15,11 +15,11 @@
 <div class="ui yellow segment" id="comments">
     @if (Model.Comments.Count == 0 && Model.CommentsEnabled)
     {
-        <p>There are no comments.</p>
+        <p><i>There are no comments.</i></p>
     }
     else if (!Model.CommentsEnabled)
     {
-        <p>Comments are disabled.</p>
+        <p><i>Comments are disabled.</i></p>
     }
     else
     {

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -19,9 +19,7 @@
     }
     else if (!Model.CommentsEnabled)
     {
-        <b>
-            <i>Comments are disabled.</i>
-        </b>
+        <p>Comments are disabled.</p>
     }
     else
     {
@@ -34,7 +32,7 @@
         <div class="ui divider"></div>
         <form class="ui reply form" action="@Url.RouteUrl(ViewContext.RouteData.Values)/postComment" method="post">
             <div class="field">
-                <textarea style="min-height: 70px; height: 70px; max-height:120px" name="msg"></textarea>
+                <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
             </div>
             <input type="submit" class="ui blue button">
         </form>

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -181,7 +181,7 @@
             @if (Model.ProfileUser.IsBanned)
             {
                 <div class="ui yellow segment" id="comments">
-                    <p>Comments are disabled because the user is banned.</p>
+                    <p><i>Comments are disabled because the user is banned.</i></p>
                 </div>
             }
             else


### PR DESCRIPTION
Add input validation to the HTML form to limit comment length to 100 characters, as well as a very minor visual nitpick embedded within.