### PR TITLE
Fix doubly sanitized strings

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
@@ -34,8 +34,6 @@ public class FriendsController : ControllerBase
         NPData? npData = await this.DeserializeBody<NPData>();
         if (npData == null) return this.BadRequest();
 
-        SanitizationHelper.SanitizeStringsInClass(npData);
-
         List<UserEntity> friends = new();
         foreach (string friendName in npData.Friends ?? new List<string>())
         {

--- a/ProjectLighthouse.Servers.GameServer/Controllers/ReportController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/ReportController.cs
@@ -37,8 +37,6 @@ public class ReportController : ControllerBase
         GameGriefReport? report = await this.DeserializeBody<GameGriefReport>();
         if (report == null) return this.BadRequest();
 
-        SanitizationHelper.SanitizeStringsInClass(report);
-
         if (string.IsNullOrWhiteSpace(report.JpegHash)) return this.BadRequest();
 
         if (!FileHelper.ResourceExists(report.JpegHash)) return this.BadRequest();

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -42,8 +42,6 @@ public class PhotosController : ControllerBase
         GamePhoto? photo = await this.DeserializeBody<GamePhoto>();
         if (photo == null) return this.BadRequest();
 
-        SanitizationHelper.SanitizeStringsInClass(photo);
-
         foreach (PhotoEntity p in this.database.Photos.Where(p => p.CreatorId == user.UserId))
         {
             if (p.LargeHash == photo.LargeHash) return this.Ok(); // photo already uplaoded

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -95,8 +95,6 @@ public class ScoreController : ControllerBase
             return this.BadRequest();
         }
 
-        SanitizationHelper.SanitizeStringsInClass(score);
-
         int slotId = id;
 
         if (slotType == "developer") slotId = await SlotHelper.GetPlaceholderSlotId(this.database, slotId, SlotType.Developer);

--- a/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
@@ -72,8 +72,6 @@ public class UserController : ControllerBase
 
         if (update == null) return this.BadRequest();
 
-        SanitizationHelper.SanitizeStringsInClass(update);
-
         if (update.Biography != null)
         {
             if (update.Biography.Length > 512) return this.BadRequest();

--- a/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
@@ -68,7 +68,6 @@ public class SlotPageController : ControllerBase
             return this.Redirect("~/slot/" + id);
         }
 
-        // Prevent potential xml injection and censor content 
         msg = CensorHelper.FilterMessage(msg);
 
         bool success = await this.database.PostComment(token.UserId, id, CommentType.Level, msg);

--- a/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
@@ -69,7 +69,6 @@ public class SlotPageController : ControllerBase
         }
 
         // Prevent potential xml injection and censor content 
-        msg = SanitizationHelper.SanitizeString(msg);
         msg = CensorHelper.FilterMessage(msg);
 
         bool success = await this.database.PostComment(token.UserId, id, CommentType.Level, msg);

--- a/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
@@ -44,8 +44,6 @@ public class UserPageController : ControllerBase
             return this.Redirect("~/user/" + id);
         }
 
-        // Prevent potential xml injection and censor content
-        msg = SanitizationHelper.SanitizeString(msg);
         msg = CensorHelper.FilterMessage(msg);
 
         bool success = await this.database.PostComment(token.UserId, id, CommentType.Profile, msg);

--- a/ProjectLighthouse.Servers.Website/Pages/SlotSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotSettingsPage.cshtml.cs
@@ -29,15 +29,13 @@ public class SlotSettingsPage : BaseLayout
 
         if (avatarHash != null) this.Slot.IconHash = avatarHash;
 
-        name = SanitizationHelper.SanitizeString(name);
         name = CensorHelper.FilterMessage(name);
         if (this.Slot.Name != name && name.Length <= 64) this.Slot.Name = name;
 
-        description = SanitizationHelper.SanitizeString(description);
         description = CensorHelper.FilterMessage(description);
         if (this.Slot.Description != description && description.Length <= 512) this.Slot.Description = description;
 
-        labels = LabelHelper.RemoveInvalidLabels(SanitizationHelper.SanitizeString(labels));
+        labels = LabelHelper.RemoveInvalidLabels(labels);
         if (this.Slot.AuthorLabels != labels) this.Slot.AuthorLabels = labels;
 
         // ReSharper disable once InvertIf

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -33,7 +33,6 @@ public class UserSettingsPage : BaseLayout
 
         if (avatarHash != null) this.ProfileUser.IconHash = avatarHash;
 
-        biography = SanitizationHelper.SanitizeString(biography);
         biography = CensorHelper.FilterMessage(biography);
 
         if (this.ProfileUser.Biography != biography && biography.Length <= 512) this.ProfileUser.Biography = biography;

--- a/ProjectLighthouse/Extensions/ControllerExtensions.cs
+++ b/ProjectLighthouse/Extensions/ControllerExtensions.cs
@@ -120,7 +120,6 @@ public static partial class ControllerExtensions
             }
             XmlSerializer serializer = new(typeof(T), root);
             T? obj = (T?)serializer.Deserialize(new StringReader(bodyString));
-            SanitizationHelper.SanitizeStringsInClass(obj);
             return obj;
         }
         catch (Exception e)

--- a/ProjectLighthouse/Helpers/SanitizationHelper.cs
+++ b/ProjectLighthouse/Helpers/SanitizationHelper.cs
@@ -1,49 +1,9 @@
 ﻿#nullable enable
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Reflection;
 
 namespace LBPUnion.ProjectLighthouse.Helpers;
 
 public static class SanitizationHelper
 {
-
-    private static readonly Dictionary<string, string> charsToReplace = new() {
-        {"<", "&lt;"},
-        {">", "&gt;"},
-        {"\"", "&quot;"},
-        {"'", "&apos;"},
-    };
-
     public static bool IsValidEmail(string? email) => !string.IsNullOrWhiteSpace(email) && new EmailAddressAttribute().IsValid(email);
-
-    public static void SanitizeStringsInClass(object? instance)
-    {
-        if (instance == null) return;
-        PropertyInfo[] properties = instance.GetType().GetProperties();
-        foreach (PropertyInfo property in properties)
-        {
-            if (property.PropertyType != typeof(string)) continue;
-
-            string? before = (string?) property.GetValue(instance);
-            
-            if (before == null) continue;
-            if (!charsToReplace.Keys.Any(k => before.Contains(k))) continue;
-            
-            property.SetValue(instance, SanitizeString(before));
-        }
-    }
-
-    public static string SanitizeString(string? input)
-    {
-        if (input == null) return "";
-
-        foreach ((string? key, string? value) in charsToReplace)
-        {
-            input = input.Replace(key, value);
-        }
-        return input;
-    }
-    
 }


### PR DESCRIPTION
After the recent serialization refactor, sanitization and desensitization are both handled by the built-in .NET systems. Before, only sanitization was handled and the manual string serialization would result in potential XML injection. Since this issue is no longer present the manually sanitized strings can be manually decoded.