### PR TITLE
Add LBP1 level scoreboards

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -290,7 +290,8 @@ public class ScoreController : ControllerBase
 
         // This is hella ugly but it technically assigns the proper rank to a score
         // var needed for Anonymous type returned from SELECT
-        var rankedScores = this.database.Scores.Where(s => s.SlotId == options.SlotId && s.Type == options.ScoreType)
+        var rankedScores = this.database.Scores.Where(s => s.SlotId == options.SlotId)
+            .Where(s => s.Type == -1 || s.Type == options.ScoreType)
             .Where(s => s.ChildSlotId == 0 || s.ChildSlotId == options.ChildSlotId)
             .AsEnumerable()
             .Where(s => options.TargetPlayerIds == null ||

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -206,7 +206,17 @@ public class ScoreController : ControllerBase
             TargetUsername = username,
             RootName = "scoreboardSegment",
         };
-        if (!HttpMethods.IsPost(this.Request.Method)) return this.Ok(this.getScores(options));
+        if (!HttpMethods.IsPost(this.Request.Method))
+        {
+            List<PlayerScoreboardResponse> scoreboardResponses = new();
+            for (int i = 1; i <= 4; i++)
+            {
+                options.ScoreType = i;
+                ScoreboardResponse response = this.getScores(options);
+                scoreboardResponses.Add(new PlayerScoreboardResponse(response.Scores, i));
+            } 
+            return this.Ok(new MultiScoreboardResponse(scoreboardResponses));
+        }
 
         GameScore? score = await this.DeserializeBody<GameScore>();
         if (score == null) return this.BadRequest();

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -200,10 +200,11 @@ public class ScoreController : ControllerBase
         LeaderboardOptions options = new()
         {
             PageSize = 10,
-            PageStart = -1,
+            PageStart = 1,
             ScoreType = -1,
-            TargetUsername = username,
             SlotId = id,
+            TargetPlayerIds = null,
+            TargetUsername = username,
             RootName = "scoreboardSegment",
         };
         if (!HttpMethods.IsPost(this.Request.Method)) return this.Ok(this.getScores(options));

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -203,7 +203,6 @@ public class ScoreController : ControllerBase
             PageStart = 1,
             ScoreType = -1,
             SlotId = id,
-            TargetPlayerIds = null,
             TargetUsername = username,
             RootName = "scoreboardSegment",
         };
@@ -288,11 +287,10 @@ public class ScoreController : ControllerBase
 
     private ScoreboardResponse getScores(LeaderboardOptions options)
     {
-
         // This is hella ugly but it technically assigns the proper rank to a score
         // var needed for Anonymous type returned from SELECT
         var rankedScores = this.database.Scores.Where(s => s.SlotId == options.SlotId)
-            .Where(s => s.Type == -1 || s.Type == options.ScoreType)
+            .Where(s => options.ScoreType == -1 || s.Type == options.ScoreType)
             .Where(s => s.ChildSlotId == 0 || s.ChildSlotId == options.ChildSlotId)
             .AsEnumerable()
             .Where(s => options.TargetPlayerIds == null ||

--- a/ProjectLighthouse/Types/Serialization/MultiScoreboardResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/MultiScoreboardResponse.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace LBPUnion.ProjectLighthouse.Types.Serialization;
+
+[XmlRoot("scoreboards")]
+public class MultiScoreboardResponse : ILbpSerializable
+{
+    public MultiScoreboardResponse() { }
+
+    public MultiScoreboardResponse(List<PlayerScoreboardResponse> scoreboards)
+    {
+        this.Scoreboards = scoreboards;
+    }
+
+    [XmlElement("topScores")]
+    public List<PlayerScoreboardResponse> Scoreboards { get; set; }
+}
+
+public class PlayerScoreboardResponse : ILbpSerializable
+{
+    public PlayerScoreboardResponse() { }
+
+    public PlayerScoreboardResponse(List<GameScore> scores, int playerCount, int firstRank = 1)
+    {
+        this.Scores = scores;
+        this.PlayerCount = playerCount;
+        this.FirstRank = firstRank;
+    }
+
+    [XmlElement("playRecord")]
+    public List<GameScore> Scores { get; set; }
+
+    [XmlAttribute("players")]
+    public int PlayerCount { get; set; }
+
+    [XmlAttribute("firstRank")]
+    public int FirstRank { get; set; }
+
+}


### PR DESCRIPTION
Implements missing endpoints in LBP1 to show highest scores and friend scores.
This also seems to have been the reason that comments in lbp1 were so buggy. After implementing the scoreboard endpoint comments loaded instantly and the next and previous page behaved correctly.
Closes #411 and closes #470
<details>
<summary>Pictures</summary>

![image](https://user-images.githubusercontent.com/16675503/229005637-4687c589-5412-475c-81c3-c14e849942ec.png)

![image](https://user-images.githubusercontent.com/16675503/229005597-9dce9d2d-ba63-4e83-9d41-c448212c062c.png)

![image](https://user-images.githubusercontent.com/16675503/229005867-38ceefa9-5ff8-4152-ae13-80409fb2a8c1.png)

</details>