### PR TITLE
Fix max character limit of comment form on website

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -32,7 +32,7 @@
         <div class="ui divider"></div>
         <form class="ui reply form" action="@Url.RouteUrl(ViewContext.RouteData.Values)/postComment" method="post">
             <div class="field">
-                <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
+                <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="256" name="msg"></textarea>
             </div>
             <input type="submit" class="ui blue button">
         </form>


### PR DESCRIPTION
The maximum character limit of comments in game is 256, not 100, this PR adjusts the max char limit for comments on the website accordingly. How many times do I have to teach you this lesson, old men!? :clueless: