### PR TITLE
Optimize slot endpoints

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -8,6 +8,7 @@ using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Matchmaking.Rooms;
+using LBPUnion.ProjectLighthouse.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Authorization;
@@ -203,14 +204,6 @@ public class SlotsController : ControllerBase
         return this.Ok(new GenericSlotResponse(slots, total, start));
     }
 
-    private class SlotCache
-    {
-        public SlotEntity? Slot { get; set; }
-        public double RatingLbp1 { get; set; }
-        public int ThumbsUp { get; set; }
-        public int Hearts { get; set; }
-    }
-
     [HttpGet("slots/highestRated")]
     public async Task<IActionResult> HighestRatedSlots([FromQuery] int pageStart, [FromQuery] int pageSize)
     {
@@ -221,7 +214,7 @@ public class SlotsController : ControllerBase
         GameVersion gameVersion = token.GameVersion;
 
         List<SlotBase> slots = (await this.database.Slots.ByGameVersion(gameVersion, false, true)
-            .Select(s => new SlotCache
+            .Select(s => new SlotMetadata
             {
                 Slot = s,
                 RatingLbp1 = this.database.RatedLevels.Where(r => r.SlotId == s.SlotId).Average(r => (double?)r.RatingLBP1) ?? 3.0,
@@ -318,7 +311,7 @@ public class SlotsController : ControllerBase
         if (pageSize <= 0) return this.BadRequest();
 
         List<SlotBase> slots = (await this.filterByRequest(gameFilterType, dateFilterType, token.GameVersion)
-            .Select(s => new SlotCache
+            .Select(s => new SlotMetadata
             {
                 Slot = s,
                 ThumbsUp = this.database.RatedLevels.Count(r => r.SlotId == s.SlotId && r.Rating == 1),
@@ -390,7 +383,7 @@ public class SlotsController : ControllerBase
         if (pageSize <= 0) return this.BadRequest();
 
         List<SlotBase> slots = (await this.filterByRequest(gameFilterType, dateFilterType, token.GameVersion)
-            .Select(s => new SlotCache
+            .Select(s => new SlotMetadata
             {
                 Slot = s,
                 Hearts = this.database.HeartedLevels.Count(r => r.SlotId == s.SlotId),

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/HighestRatedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/HighestRatedCategory.cs
@@ -1,10 +1,11 @@
 #nullable enable
-using System.Security.Cryptography;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Levels;
+using LBPUnion.ProjectLighthouse.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Users;
+using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 
@@ -14,13 +15,27 @@ public class HighestRatedCategory : Category
     public override string Description { get; set; } = "Community Highest Rated content";
     public override string IconHash { get; set; } = "g820603";
     public override string Endpoint { get; set; } = "thumbs";
-    public override SlotEntity? GetPreviewSlot(DatabaseContext database) => database.Slots.Where(s => s.Type == SlotType.User).AsEnumerable().MaxBy(s => s.Thumbsup);
-    public override IEnumerable<SlotEntity> GetSlots
-        (DatabaseContext database, int pageStart, int pageSize)
-        => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
-            .AsEnumerable()
-            .OrderByDescending(s => s.Thumbsup)
-            .ThenBy(_ => RandomNumberGenerator.GetInt32(int.MaxValue))
+    public override SlotEntity? GetPreviewSlot(DatabaseContext database) =>
+        database.Slots.Where(s => s.Type == SlotType.User)
+            .Select(s => new SlotMetadata
+            {
+                Slot = s,
+                ThumbsUp = database.RatedLevels.Count(r => r.SlotId == s.SlotId && r.Rating == 1),
+            })
+            .OrderByDescending(s => s.ThumbsUp)
+            .Select(s => s.Slot)
+            .FirstOrDefault();
+
+    public override IEnumerable<SlotEntity> GetSlots(DatabaseContext database, int pageStart, int pageSize) =>
+        database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
+            .Select(s => new SlotMetadata
+            {
+                Slot = s,
+                ThumbsUp = database.RatedLevels.Count(r => r.SlotId == s.SlotId && r.Rating == 1),
+            })
+            .OrderByDescending(s => s.ThumbsUp)
+            .ThenBy(_ => EF.Functions.Random())
+            .Select(s => s.Slot)
             .Skip(Math.Max(0, pageStart - 1))
             .Take(Math.Min(pageSize, 20));
     public override int GetTotalSlots(DatabaseContext database) => database.Slots.Count(s => s.Type == SlotType.User);

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
@@ -1,9 +1,9 @@
 #nullable enable
-using System.Security.Cryptography;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Levels;
+using LBPUnion.ProjectLighthouse.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Users;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
@@ -14,13 +14,27 @@ public class MostHeartedCategory : Category
     public override string Description { get; set; } = "The Most Hearted Content";
     public override string IconHash { get; set; } = "g820607";
     public override string Endpoint { get; set; } = "mostHearted";
-    public override SlotEntity? GetPreviewSlot(DatabaseContext database) => database.Slots.Where(s => s.Type == SlotType.User).AsEnumerable().MaxBy(s => s.Hearts);
-    public override IEnumerable<SlotEntity> GetSlots
-        (DatabaseContext database, int pageStart, int pageSize)
-        => database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
-            .AsEnumerable()
+
+    public override SlotEntity? GetPreviewSlot(DatabaseContext database) =>
+        database.Slots.Where(s => s.Type == SlotType.User)
+            .Select(s => new SlotMetadata
+            {
+                Slot = s,
+                Hearts = database.HeartedLevels.Count(r => r.SlotId == s.SlotId),
+            })
             .OrderByDescending(s => s.Hearts)
-            .ThenBy(_ => RandomNumberGenerator.GetInt32(int.MaxValue))
+            .Select(s => s.Slot)
+            .FirstOrDefault();
+
+    public override IEnumerable<SlotEntity> GetSlots(DatabaseContext database, int pageStart, int pageSize) =>
+        database.Slots.ByGameVersion(GameVersion.LittleBigPlanet3, false, true)
+            .Select(s => new SlotMetadata
+            {
+                Slot = s,
+                Hearts = database.HeartedLevels.Count(r => r.SlotId == s.SlotId),
+            })
+            .OrderByDescending(s => s.ThumbsUp)
+            .Select(s => s.Slot)
             .Skip(Math.Max(0, pageStart - 1))
             .Take(Math.Min(pageSize, 20));
     public override int GetTotalSlots(DatabaseContext database) => database.Slots.Count(s => s.Type == SlotType.User);

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/MostHeartedCategory.cs
@@ -33,7 +33,7 @@ public class MostHeartedCategory : Category
                 Slot = s,
                 Hearts = database.HeartedLevels.Count(r => r.SlotId == s.SlotId),
             })
-            .OrderByDescending(s => s.ThumbsUp)
+            .OrderByDescending(s => s.Hearts)
             .Select(s => s.Slot)
             .Skip(Math.Max(0, pageStart - 1))
             .Take(Math.Min(pageSize, 20));

--- a/ProjectLighthouse/Types/Misc/SlotMetadata.cs
+++ b/ProjectLighthouse/Types/Misc/SlotMetadata.cs
@@ -1,0 +1,11 @@
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+
+namespace LBPUnion.ProjectLighthouse.Types.Misc;
+
+public class SlotMetadata
+{
+    public required SlotEntity Slot { get; init; }
+    public double RatingLbp1 { get; init; }
+    public int ThumbsUp { get; init; }
+    public int Hearts { get; init; }
+}

--- a/ProjectLighthouse/Types/Serialization/GameUserSlot.cs
+++ b/ProjectLighthouse/Types/Serialization/GameUserSlot.cs
@@ -60,6 +60,7 @@ public class GameUserSlot : SlotBase, INeedsPreparationForSerialization
 
     [XmlElement("resource")]
     public string[]? Resources { get; set; }
+    public bool ShouldSerializeResources() => false;
 
     [XmlElement("icon")]
     public string IconHash { get; set; } = "";


### PR DESCRIPTION
Removes usages of client-side evaluation which should help to improve performance in endpoints that are sorted by calculated fields (most hearted, highest rated, etc)
Also removes the serialization of a slot's resources since it isn't used by the game at all.