### PR TITLE
Add basic ability to flag duplicate levels

### DIFF
--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -77,13 +77,12 @@ public class ModerationSlotController : ControllerBase
 
         SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.BadRequest();
-        if (slot.Creator == null) return this.StatusCode(500);
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
             description: @$"Level **{slot.Name}** (#{slot.SlotId}) has been flagged as a duplicate level.
                             
                             **Reporter:** {user.Username}
-                            **Offender:** {slot.Creator.Username}",
+                            **Offender:** {slot.Creator!.Username}",
             dest: WebhookHelper.WebhookDestination.Moderation);
 
         return this.Redirect($"~/slot/{slot.SlotId}");

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -80,10 +80,11 @@ public class ModerationSlotController : ControllerBase
         if (slot.CreatorId == user.UserId) return this.Redirect($"~/slot/{slot.SlotId}");
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
-            description: @$"Level **{slot.Name}** (#{slot.SlotId}) has been flagged as a duplicate level.
+            description: @$"Level [**{slot.Name}**]({ServerConfiguration.Instance.ExternalUrl}/slot/${slot.SlotId}) has been flagged as a duplicate level.
                             
-                            **Reporter:** {user.Username}
-                            **Offender:** {slot.Creator!.Username}",
+                            > **Reporter:** [{user.Username}]({ServerConfiguration.Instance.ExternalUrl}/user/${user.UserId})
+                            > **Offender:** [{slot.Creator!.Username}]({ServerConfiguration.Instance.ExternalUrl}/slot/${slot.Creator!.UserId})
+                            > **Level Hash:** {slot.RootLevel}",
             dest: WebhookHelper.WebhookDestination.Moderation);
 
         return this.Redirect($"~/slot/{slot.SlotId}");

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -76,7 +76,7 @@ public class ModerationSlotController : ControllerBase
         if (user == null) return this.StatusCode(403);
 
         SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == id);
-        if (slot == null) return this.StatusCode(400);
+        if (slot == null) return this.BadRequest();
         if (slot.Creator == null) return this.StatusCode(500);
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -79,11 +79,13 @@ public class ModerationSlotController : ControllerBase
         if (slot == null) return this.BadRequest();
         if (slot.CreatorId == user.UserId) return this.Redirect($"~/slot/{slot.SlotId}");
 
+        string externalUrl = ServerConfiguration.Instance.ExternalUrl;
+
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
-            description: @$"Level [**{slot.Name}**]({ServerConfiguration.Instance.ExternalUrl}/slot/${slot.SlotId}) has been flagged as a duplicate level.
+            description: @$"Level [**{slot.Name}**]({externalUrl}/slot/${slot.SlotId}) has been flagged as a duplicate level.
                             
-                            > **Reporter:** [{user.Username}]({ServerConfiguration.Instance.ExternalUrl}/user/${user.UserId})
-                            > **Offender:** [{slot.Creator!.Username}]({ServerConfiguration.Instance.ExternalUrl}/slot/${slot.Creator!.UserId})
+                            > **Reporter:** [{user.Username}]({externalUrl}/user/${user.UserId})
+                            > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/${slot.Creator!.UserId})
                             > **Level Hash:** {slot.RootLevel}",
             dest: WebhookHelper.WebhookDestination.Moderation);
 

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -82,7 +82,7 @@ public class ModerationSlotController : ControllerBase
         string externalUrl = ServerConfiguration.Instance.ExternalUrl;
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
-            description: @$"Level [**{slot.Name}**]({externalUrl}/slot/${slot.SlotId}) has been flagged as a duplicate level.
+            description: @$"Level [**{slot.Name}**]({externalUrl}/slot/{slot.SlotId}) has been flagged as a duplicate level.
                             
                             > **Reporter:** [{user.Username}]({externalUrl}/user/${user.UserId})
                             > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/${slot.Creator!.UserId})

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -72,11 +72,12 @@ public class ModerationSlotController : ControllerBase
     [HttpGet("flag")]
     public async Task<IActionResult> FlagLevel([FromRoute] int id)
     {
+        UserEntity? user = this.database.UserFromWebRequest(this.Request);
+        if (user == null) return this.Redirect($"~/slot/{id}");
+
         SlotEntity? slot = await this.database.Slots.Include(s => s.Creator).FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.BadRequest();
-
-        UserEntity? user = this.database.UserFromWebRequest(this.Request);
-        if (user == null) return this.Redirect($"~/slot/{slot.SlotId}");
+        if (slot.CreatorId == user.UserId) return this.Redirect($"~/slot/{slot.SlotId}");
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
             description: @$"Level **{slot.Name}** (#{slot.SlotId}) has been flagged as a duplicate level.

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -85,7 +85,7 @@ public class ModerationSlotController : ControllerBase
             description: @$"Level [**{slot.Name}**]({externalUrl}/slot/{slot.SlotId}) has been flagged as a duplicate level.
                             
                             > **Reporter:** [{user.Username}]({externalUrl}/user/{user.UserId})
-                            > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/${slot.Creator!.UserId})
+                            > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/{slot.Creator!.UserId})
                             > **Level Hash:** {slot.RootLevel}",
             dest: WebhookHelper.WebhookDestination.Moderation);
 

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -75,7 +75,7 @@ public class ModerationSlotController : ControllerBase
         UserEntity? user = this.database.UserFromWebRequest(this.Request);
         if (user == null) return this.StatusCode(403);
 
-        SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == id);
+        SlotEntity? slot = await this.database.Slots.Include(s => s.Creator).FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.BadRequest();
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -85,7 +85,7 @@ public class ModerationSlotController : ControllerBase
             description: @$"Level [**{slot.Name}**]({externalUrl}/slot/{slot.SlotId}) has been flagged as a duplicate level.
                             
                             > **Reporter:** [{user.Username}]({externalUrl}/user/{user.UserId})
-                            > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/{slot.Creator!.UserId})
+                            > **Offender:** [{slot.Creator!.Username}]({externalUrl}/user/{slot.CreatorId})
                             > **Level Hash:** {slot.RootLevel}",
             dest: WebhookHelper.WebhookDestination.Moderation);
 

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -84,7 +84,7 @@ public class ModerationSlotController : ControllerBase
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
             description: @$"Level [**{slot.Name}**]({externalUrl}/slot/{slot.SlotId}) has been flagged as a duplicate level.
                             
-                            > **Reporter:** [{user.Username}]({externalUrl}/user/${user.UserId})
+                            > **Reporter:** [{user.Username}]({externalUrl}/user/{user.UserId})
                             > **Offender:** [{slot.Creator!.Username}]({externalUrl}/slot/${slot.Creator!.UserId})
                             > **Level Hash:** {slot.RootLevel}",
             dest: WebhookHelper.WebhookDestination.Moderation);

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -72,11 +72,11 @@ public class ModerationSlotController : ControllerBase
     [HttpGet("flag")]
     public async Task<IActionResult> FlagLevel([FromRoute] int id)
     {
-        UserEntity? user = this.database.UserFromWebRequest(this.Request);
-        if (user == null) return this.StatusCode(403);
-
         SlotEntity? slot = await this.database.Slots.Include(s => s.Creator).FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.BadRequest();
+
+        UserEntity? user = this.database.UserFromWebRequest(this.Request);
+        if (user == null) return this.Redirect($"~/slot/{slot.SlotId}");
 
         await WebhookHelper.SendWebhook(title: "New duplicate level flag",
             description: @$"Level **{slot.Name}** (#{slot.SlotId}) has been flagged as a duplicate level.

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
@@ -104,7 +104,7 @@
     </div>
     <div class="cardButtons">
             <br>
-            @if (user != null && !mini && (user.IsModerator || user.UserId == Model.CreatorId))
+            @if (user != null && !mini && (user.IsModerator || Model.CreatorId == user.UserId))
             {
                 <a class="ui blue tiny button" href="/slot/@Model.SlotId/settings" title="Settings">
                     <i class="cog icon" style="margin: 0"></i>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
@@ -110,6 +110,14 @@
                     <i class="cog icon" style="margin: 0"></i>
                 </a>
             }
+            
+            @if (user != null && !mini && (user.UserId != Model.CreatorId))
+            {
+                <a class="ui red tiny button" href="/moderation/slot/@Model.SlotId/flag" title="Flag As Duplicate"
+                    onclick='return confirm("Are you sure you want to flag this level as a duplicate? False reports may result in punishment.")'>
+                    <i class="sync icon" style="margin: 0"></i>
+                </a>
+            }
         </div>
     <div class="cardButtons" style="margin-left: 0">
         <br>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
@@ -115,7 +115,7 @@
             {
                 <a class="ui red tiny button" href="/moderation/slot/@Model.SlotId/flag" title="Flag As Duplicate"
                     onclick='return confirm("Are you sure you want to flag this level as a duplicate? False reports may result in punishment.")'>
-                    <i class="sync icon" style="margin: 0"></i>
+                    <i class="flag icon" style="margin: 0"></i>
                 </a>
             }
         </div>


### PR DESCRIPTION
This PR adds the basic ability for users to flag duplicated levels on the instance. Upon clicking the red button and confirming, a webhook is delivered to the configured `WebhookDestination.Moderation` URL, containing the duplicate level name/ID, as well as the reporter/level creator usernames. This allows whoever is reviewing the case to verify the original uploader as opposed to the copied level.

![image](https://user-images.githubusercontent.com/68549366/234471349-ba30b191-16fb-44f1-92ce-4f1d2df65d23.png)