### PR TITLE
Rewrite captcha system

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
-using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Users;
 using LBPUnion.ProjectLighthouse.StorableLists.Stores;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -3,7 +3,6 @@ using Discord;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
-using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
@@ -17,7 +16,6 @@ using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging.Configuration;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
-using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Users;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;

--- a/ProjectLighthouse.Servers.Website/Captcha/CaptchaService.cs
+++ b/ProjectLighthouse.Servers.Website/Captcha/CaptchaService.cs
@@ -1,0 +1,61 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Configuration.ConfigurationCategories;
+using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Types.Logging;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json.Linq;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Captcha;
+
+public class CaptchaService : ICaptchaService
+{
+    private readonly HttpClient client;
+
+    public CaptchaService(HttpClient client)
+    {
+        this.client = client;
+    }
+
+    public async Task<bool> VerifyCaptcha(HttpRequest request)
+    {
+        if (!ServerConfiguration.Instance.Captcha.CaptchaEnabled) return true;
+
+        string keyName = ServerConfiguration.Instance.Captcha.Type switch
+        {
+            CaptchaType.HCaptcha => "h-captcha-response",
+            CaptchaType.ReCaptcha => "g-recaptcha-response",
+            _ => throw new ArgumentOutOfRangeException(nameof(request),
+                @$"Unknown captcha type: {ServerConfiguration.Instance.Captcha.Type}"),
+        };
+
+        bool gotCaptcha = request.Form.TryGetValue(keyName, out StringValues values);
+        if (!gotCaptcha) return false;
+
+        string? captchaToken = values[0];
+        if (captchaToken == null) return false;
+
+        List<KeyValuePair<string, string>> payload = new()
+        {
+            new KeyValuePair<string, string>("secret", ServerConfiguration.Instance.Captcha.Secret),
+            new KeyValuePair<string, string>("response", captchaToken),
+        };
+
+        try
+        {
+            using HttpResponseMessage response =
+                await this.client.PostAsync("siteverify", new FormUrlEncodedContent(payload));
+            if (!response.IsSuccessStatusCode) return false;
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+
+            // We only really care about the success result, so we just parse that
+            return bool.Parse(JObject.Parse(responseBody)["success"]?.ToString() ?? "false");
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex.ToDetailedException(), LogArea.HTTP);
+        }
+        return false;
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Captcha/ICaptchaService.cs
+++ b/ProjectLighthouse.Servers.Website/Captcha/ICaptchaService.cs
@@ -1,0 +1,6 @@
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Captcha;
+
+public interface ICaptchaService
+{
+    Task<bool> VerifyCaptcha(HttpRequest request);
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml.cs
@@ -3,10 +3,10 @@ using System.Web;
 using JetBrains.Annotations;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
-using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Localization.StringLists;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.Website.Captcha;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -18,8 +18,12 @@ namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login;
 
 public class LoginForm : BaseLayout
 {
-    public LoginForm(DatabaseContext database) : base(database)
-    {}
+    private readonly ICaptchaService captchaService;
+
+    public LoginForm(DatabaseContext database, ICaptchaService captchaService) : base(database)
+    {
+        this.captchaService = captchaService;
+    }
 
     public string? Error { get; private set; }
 
@@ -38,7 +42,7 @@ public class LoginForm : BaseLayout
             return this.Page();
         }
 
-        if (!await this.Request.CheckCaptchaValidity())
+        if (!await this.captchaService.VerifyCaptcha(this.Request))
         {
             this.Error = this.Translate(ErrorStrings.CaptchaFailed);
             return this.Page();

--- a/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml.cs
@@ -2,9 +2,9 @@ using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
-using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Localization.StringLists;
+using LBPUnion.ProjectLighthouse.Servers.Website.Captcha;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -15,8 +15,12 @@ namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login;
 
 public class RegisterForm : BaseLayout
 {
-    public RegisterForm(DatabaseContext database) : base(database)
-    { }
+    private readonly ICaptchaService captchaService;
+
+    public RegisterForm(DatabaseContext database, ICaptchaService captchaService) : base(database)
+    {
+        this.captchaService = captchaService;
+    }
 
     public string? Error { get; private set; }
 
@@ -68,7 +72,7 @@ public class RegisterForm : BaseLayout
             return this.Page();
         }
 
-        if (!await this.Request.CheckCaptchaValidity())
+        if (!await this.captchaService.VerifyCaptcha(this.Request))
         {
             this.Error = this.Translate(ErrorStrings.CaptchaFailed);
             return this.Page();

--- a/ProjectLighthouse/Extensions/RequestExtensions.cs
+++ b/ProjectLighthouse/Extensions/RequestExtensions.cs
@@ -1,36 +1,12 @@
 #nullable enable
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Http;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using LBPUnion.ProjectLighthouse.Configuration;
-using LBPUnion.ProjectLighthouse.Configuration.ConfigurationCategories;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
-using Newtonsoft.Json.Linq;
 
 namespace LBPUnion.ProjectLighthouse.Extensions;
 
 public static partial class RequestExtensions
 {
-    static RequestExtensions()
-    {
-        Uri captchaUri = ServerConfiguration.Instance.Captcha.Type switch
-        {
-            CaptchaType.HCaptcha => new Uri("https://hcaptcha.com"),
-            CaptchaType.ReCaptcha => new Uri("https://www.google.com/recaptcha/api/"),
-            _ => throw new ArgumentOutOfRangeException(),
-        };
-        
-        client = new HttpClient
-        {
-            BaseAddress = captchaUri,
-        };
-    }
-    
     #region Mobile Checking
 
     // yoinked and adapted from https://stackoverflow.com/a/68641796
@@ -42,51 +18,4 @@ public static partial class RequestExtensions
     public static bool IsMobile(this HttpRequest request) => MobileCheckRegex().IsMatch(request.Headers[HeaderNames.UserAgent].ToString());
 
     #endregion
-
-    #region Captcha
-
-    private static readonly HttpClient client;
-
-    [SuppressMessage("ReSharper", "ArrangeObjectCreationWhenTypeNotEvident")]
-    private static async Task<bool> verifyCaptcha(string? token)
-    {
-        if (!ServerConfiguration.Instance.Captcha.CaptchaEnabled) return true;
-
-        if (token == null) return false;
-
-        List<KeyValuePair<string, string>> payload = new()
-        {
-            new("secret", ServerConfiguration.Instance.Captcha.Secret),
-            new("response", token),
-        };
-
-        HttpResponseMessage response = await client.PostAsync("siteverify", new FormUrlEncodedContent(payload));
-
-        response.EnsureSuccessStatusCode();
-
-        string responseBody = await response.Content.ReadAsStringAsync();
-
-        // We only really care about the success result, nothing else that hcaptcha sends us, so lets only parse that.
-        bool success = bool.Parse(JObject.Parse(responseBody)["success"]?.ToString() ?? "false");
-        return success;
-    }
-
-    public static async Task<bool> CheckCaptchaValidity(this HttpRequest request)
-    {
-        if (!ServerConfiguration.Instance.Captcha.CaptchaEnabled) return true;
-
-        string keyName = ServerConfiguration.Instance.Captcha.Type switch
-        {
-            CaptchaType.HCaptcha => "h-captcha-response",
-            CaptchaType.ReCaptcha => "g-recaptcha-response",
-            _ => throw new ArgumentOutOfRangeException(nameof(request), @$"Unknown captcha type: {ServerConfiguration.Instance.Captcha.Type}"),
-        };
-            
-        bool gotCaptcha = request.Form.TryGetValue(keyName, out StringValues values);
-        if (!gotCaptcha) return false;
-
-        return await verifyCaptcha(values[0]);
-    }
-    #endregion
-
 }

--- a/ProjectLighthouse/Types/Serialization/Author.cs
+++ b/ProjectLighthouse/Types/Serialization/Author.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/CategoryListResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/CategoryListResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/CommentListResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/CommentListResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/GameCategory.cs
+++ b/ProjectLighthouse/Types/Serialization/GameCategory.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;

--- a/ProjectLighthouse/Types/Serialization/GameComment.cs
+++ b/ProjectLighthouse/Types/Serialization/GameComment.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using LBPUnion.ProjectLighthouse.Database;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using Microsoft.EntityFrameworkCore;
 

--- a/ProjectLighthouse/Types/Serialization/GameDeveloperSlot.cs
+++ b/ProjectLighthouse/Types/Serialization/GameDeveloperSlot.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using System.Xml.Serialization;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Helpers;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using Microsoft.EntityFrameworkCore;

--- a/ProjectLighthouse/Types/Serialization/GameDeveloperVideos.cs
+++ b/ProjectLighthouse/Types/Serialization/GameDeveloperVideos.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/GameGriefReport.cs
+++ b/ProjectLighthouse/Types/Serialization/GameGriefReport.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Moderation;
 using LBPUnion.ProjectLighthouse.Types.Moderation.Reports;
 

--- a/ProjectLighthouse/Types/Serialization/GamePhotoSubject.cs
+++ b/ProjectLighthouse/Types/Serialization/GamePhotoSubject.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;

--- a/ProjectLighthouse/Types/Serialization/GamePlaylist.cs
+++ b/ProjectLighthouse/Types/Serialization/GamePlaylist.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Xml.Serialization;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using Microsoft.EntityFrameworkCore;
 

--- a/ProjectLighthouse/Types/Serialization/GameScore.cs
+++ b/ProjectLighthouse/Types/Serialization/GameScore.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Linq;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;

--- a/ProjectLighthouse/Types/Serialization/GameUser.cs
+++ b/ProjectLighthouse/Types/Serialization/GameUser.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Serialization;

--- a/ProjectLighthouse/Types/Serialization/GenericPlaylistResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/GenericPlaylistResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/GenericUserResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/GenericUserResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/IconList.cs
+++ b/ProjectLighthouse/Types/Serialization/IconList.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/MinimalUserListResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/MinimalUserListResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/NpHandle.cs
+++ b/ProjectLighthouse/Types/Serialization/NpHandle.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/PhotoListResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/PhotoListResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/PhotoSlot.cs
+++ b/ProjectLighthouse/Types/Serialization/PhotoSlot.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;

--- a/ProjectLighthouse/Types/Serialization/PlanetStatsResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/PlanetStatsResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/PlaylistResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/PlaylistResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/ReviewResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/ReviewResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/ReviewSlot.cs
+++ b/ProjectLighthouse/Types/Serialization/ReviewSlot.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;

--- a/ProjectLighthouse/Types/Serialization/ScoreboardResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/ScoreboardResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/TelemetryConfigResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/TelemetryConfigResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 

--- a/ProjectLighthouse/Types/Serialization/UserListResponse.cs
+++ b/ProjectLighthouse/Types/Serialization/UserListResponse.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Xml.Serialization;
-using LBPUnion.ProjectLighthouse.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Types.Serialization;
 


### PR DESCRIPTION
This PR makes the captcha system use a DI-injected HttpClient which should help prevent issues where one request timing out prevents any more requests from being made. The timeout has also been adjusted to be 5 seconds rather than the default of 100 seconds. Many unused directives have also been removed by Rider Auto-Analysis.