### PR TITLE
Patch account suspended page display issues

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -12,8 +12,6 @@
 }
 
 <div class="ui middle aligned left aligned">
-    <h1>@Model.Translate(ModerationStrings.SuspensionHeading)</h1>  
-
     <p>
         @Model.Translate(ModerationStrings.SuspensionExplanation, ServerConfiguration.Instance.Customization.ServerName)
     </p>         

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
@@ -25,7 +25,9 @@ public class BannedUserPage : BaseLayout
         if (!user.IsBanned) return this.Redirect("~/");
 
         ModerationCaseEntity? modCase = await this.Database.Cases
-            .FirstOrDefaultAsync(c => c.AffectedId == user.UserId && c.Type == CaseType.UserBan);
+            .LastOrDefaultAsync(c => c.AffectedId == user.UserId
+                                     && c.Type == CaseType.UserBan
+                                     && !c.Dismissed);
 
         if (modCase == null) return this.Redirect("~/");
 


### PR DESCRIPTION
Patches two issues arising from #773.

* Two title headings would display on page
* Renderer would pull oldest case rather than newest, and would still show dismissed cases.
  * Technically, showing a dismissed case shouldn't happen anyways, but still a good thing to check for.
