### PR TITLE
Refactor error modal into its own partial

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Email/SetEmailForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Email/SetEmailForm.cshtml
@@ -1,6 +1,5 @@
 @page "/login/setEmail"
 @using LBPUnion.ProjectLighthouse.Configuration
-@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Email.SetEmailForm
 
 @{
@@ -12,12 +11,12 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    <div class="ui negative message">
-        <div class="header">
-            @Model.Translate(GeneralStrings.Error)
-        </div>
-        <p style="white-space: pre-line">@Model.Error</p>
-    </div>
+    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+           {
+               {
+                   "Error", Model.Error
+               },
+           })
 }
 
 <form class="ui form" onsubmit="return onSubmit(this)" method="post">

--- a/ProjectLighthouse.Servers.Website/Pages/Email/SetEmailForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Email/SetEmailForm.cshtml
@@ -1,5 +1,6 @@
 @page "/login/setEmail"
 @using LBPUnion.ProjectLighthouse.Configuration
+@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Email.SetEmailForm
 
 @{
@@ -11,12 +12,7 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-           {
-               {
-                   "Error", Model.Error
-               },
-           })
+    @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
 }
 
 <form class="ui form" onsubmit="return onSubmit(this)" method="post">

--- a/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml
@@ -29,21 +29,21 @@
 
 <div class="ui middle aligned center aligned grid">
     <form class="ui form" onsubmit="return onSubmit(this)" method="post">
-    @if (!string.IsNullOrWhiteSpace(Model.Error))
+        @if (!string.IsNullOrWhiteSpace(Model.Error))
         {
-            <div class="ui negative message">
-                <div class="header">
-                    @Model.Translate(GeneralStrings.Error)
-                </div>
-                <p style="white-space: pre-line">@Model.Error</p>
-            </div>
+            @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+                   {
+                       {
+                           "Error", Model.Error
+                       },
+                   })
         }
         @Html.AntiForgeryToken()
         <input type="hidden" id="redirect" name="redirect">
-    
+
         <div class="column">
             <h2 class="ui black image header centered">
-                <img src="~/@(ServerConfiguration.Instance.WebsiteConfiguration.PrideEventEnabled && DateTime.Now.Month == 6 ? "logo-pride.png" : "logo-color.png")" 
+                <img src="~/@(ServerConfiguration.Instance.WebsiteConfiguration.PrideEventEnabled && DateTime.Now.Month == 6 ? "logo-pride.png" : "logo-color.png")"
                      alt="Instance logo"
                      class="image"
                      style="width: 128px;"/>
@@ -84,7 +84,7 @@
                     @Model.Translate(GeneralStrings.ForgotPassword)
                 </div>
             </a>
-            
+
             @if (ServerConfiguration.Instance.Authentication.RegistrationEnabled)
             {
                 <div class="ui divider"></div>

--- a/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml
@@ -31,12 +31,7 @@
     <form class="ui form" onsubmit="return onSubmit(this)" method="post">
         @if (!string.IsNullOrWhiteSpace(Model.Error))
         {
-            @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-                   {
-                       {
-                           "Error", Model.Error
-                       },
-                   })
+            @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
         }
         @Html.AntiForgeryToken()
         <input type="hidden" id="redirect" name="redirect">

--- a/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetPage.cshtml
@@ -1,4 +1,5 @@
 @page "/passwordReset"
+@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login.PasswordResetPage
 
 @{
@@ -25,12 +26,7 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-           {
-               {
-                   "Error", Model.Error
-               },
-           })
+    @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
 }
 
 <div class="ui middle aligned center aligned grid">

--- a/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetPage.cshtml
@@ -1,6 +1,4 @@
 @page "/passwordReset"
-@using LBPUnion.ProjectLighthouse.Configuration
-@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login.PasswordResetPage
 
 @{
@@ -27,46 +25,46 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    <div class="ui negative message">
-        <div class="header">
-            @Model.Translate(GeneralStrings.Error)
-        </div>
-        <p>@Model.Error</p>
-    </div>
+    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+           {
+               {
+                   "Error", Model.Error
+               },
+           })
 }
 
 <div class="ui middle aligned center aligned grid">
-<form onsubmit="return onSubmit(this)" method="post">
-    @Html.AntiForgeryToken()
+    <form onsubmit="return onSubmit(this)" method="post">
+        @Html.AntiForgeryToken()
 
-    <div class="column">
-        <h2 class="ui black image header centered">
-            <div class="content">
-                @Model.Title
-            </div>
-        </h2>
-
-        <div class="ui form">
-            <div class="ui field">
-                <label>Password</label>
-                <div class="ui left icon input">
-                    <input type="password" id="password" placeholder="Password" >
-                    <input type="hidden" name="password" id="password-submit">
-                    <i class="lock icon"></i>
+        <div class="column">
+            <h2 class="ui black image header centered">
+                <div class="content">
+                    @Model.Title
                 </div>
-            </div>
+            </h2>
 
-            <div class="ui field">
-                <label>Confirm Password</label>
-                <div class="ui left icon input">
-                    <input type="password" id="confirmPassword" placeholder="Confirm Password">
-                    <input type="hidden" name="confirmPassword" id="confirmPassword-submit">
-                    <i class="lock icon"></i>
+            <div class="ui form">
+                <div class="ui field">
+                    <label>Password</label>
+                    <div class="ui left icon input">
+                        <input type="password" id="password" placeholder="Password">
+                        <input type="hidden" name="password" id="password-submit">
+                        <i class="lock icon"></i>
+                    </div>
                 </div>
+
+                <div class="ui field">
+                    <label>Confirm Password</label>
+                    <div class="ui left icon input">
+                        <input type="password" id="confirmPassword" placeholder="Confirm Password">
+                        <input type="hidden" name="confirmPassword" id="confirmPassword-submit">
+                        <i class="lock icon"></i>
+                    </div>
+                </div>
+                <input type="submit" value="Reset password" id="submit" class="ui fluid blue button"><br>
+                <div class="ui divider hidden"></div>
             </div>
-            <input type="submit" value="Reset password" id="submit" class="ui fluid blue button"><br>
-            <div class="ui divider hidden"></div>
         </div>
-    </div>
-</form>
+    </form>
 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetRequestForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetRequestForm.cshtml
@@ -9,12 +9,7 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-           {
-               {
-                   "Error", Model.Error
-               },
-           })
+    @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
 }
 
 @if (!string.IsNullOrWhiteSpace(Model.Status))

--- a/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetRequestForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/PasswordResetRequestForm.cshtml
@@ -5,18 +5,18 @@
 @{
     Layout = "Layouts/BaseLayout";
     Model.Title = "Password Reset";
-}             
-        
+}
+
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    <div class="ui negative message">
-        <div class="header">
-            @Model.Translate(GeneralStrings.Error)
-        </div>
-        <p style="white-space: pre-line">@Model.Error</p>
-    </div>
+    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+           {
+               {
+                   "Error", Model.Error
+               },
+           })
 }
-         
+
 @if (!string.IsNullOrWhiteSpace(Model.Status))
 {
     <div class="ui positive message">
@@ -28,7 +28,7 @@
 }
 
 <form class="ui form" method="post">
-    @Html.AntiForgeryToken() 
+    @Html.AntiForgeryToken()
 
     <input type="text" autocomplete="no" id="email" placeholder="@Model.Translate(GeneralStrings.Email)" name="email"/><br/><br/>
     <input type="submit" value="Request Password Reset" class="ui blue button"/>

--- a/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml
@@ -25,12 +25,7 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-           {
-               {
-                   "Error", Model.Error
-               },
-           })
+    @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
 }
 
 @if (Model.Username == null)

--- a/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml
@@ -25,17 +25,19 @@
 
 @if (!string.IsNullOrWhiteSpace(Model.Error))
 {
-    <div class="ui negative message">
-        <div class="header">
-            @Model.Translate(GeneralStrings.Error)
-        </div>
-        <p>@Model.Error</p>
-    </div>
+    @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+           {
+               {
+                   "Error", Model.Error
+               },
+           })
 }
 
 @if (Model.Username == null)
 {
-    <p><b>@Model.Translate(RegisterStrings.UsernameNotice)</b></p>
+    <p>
+        <b>@Model.Translate(RegisterStrings.UsernameNotice)</b>
+    </p>
 }
 
 <form class="ui form" onsubmit="return onSubmit(this)" method="post">

--- a/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml
@@ -1,4 +1,5 @@
 @page "/moderation/newCase"
+@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Moderation.NewCasePage
 
 @{
@@ -11,12 +12,7 @@
 
     @if (!string.IsNullOrWhiteSpace(Model.Error))
     {
-        @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-               {
-                   {
-                       "Error", Model.Error
-                   },
-               })
+        @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
     }
 
     <input type="hidden" name="type" value="@((int)Model.Type)"/>

--- a/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml
@@ -1,5 +1,4 @@
 @page "/moderation/newCase"
-@using LBPUnion.ProjectLighthouse.Localization.StringLists
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Moderation.NewCasePage
 
 @{
@@ -9,17 +8,17 @@
 
 <form method="post">
     @Html.AntiForgeryToken()
-    
+
     @if (!string.IsNullOrWhiteSpace(Model.Error))
     {
-        <div class="ui negative message">
-            <div class="header">
-                @Model.Translate(GeneralStrings.Error)
-            </div>
-            <p style="white-space: pre-line">@Model.Error</p>
-        </div>
+        @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+               {
+                   {
+                       "Error", Model.Error
+                   },
+               })
     }
-    
+
     <input type="hidden" name="type" value="@((int)Model.Type)"/>
     <input type="hidden" name="affectedId" value="@Model.AffectedId"/>
 
@@ -27,7 +26,7 @@
         <label for="reason" class="ui blue label">Reason: </label>
         <input type="text" name="reason" id="reason"/>
     </div><br/><br/>
-    
+
     <div class="ui left labeled input">
         <label for="mod-notes" class="ui blue label">Mod Notes: </label>
         <input type="text" name="modNotes" id="mod-notes"/>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ErrorModalPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ErrorModalPartial.cshtml
@@ -1,11 +1,8 @@
-﻿@using LBPUnion.ProjectLighthouse.Localization.StringLists
-@{
-    string error = (string?)ViewData["Error"] ?? "";
-}
+﻿@model (string Title, string Message)
 
 <div class="ui negative message">
     <div class="header">
-        @Model.Translate(GeneralStrings.Error)
+        @Model.Title
     </div>
-    <p style="white-space: pre-line">@error</p>
+    <p style="white-space: pre-line">@Model.Message</p>
 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ErrorModalPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ErrorModalPartial.cshtml
@@ -1,0 +1,11 @@
+﻿@using LBPUnion.ProjectLighthouse.Localization.StringLists
+@{
+    string error = (string?)ViewData["Error"] ?? "";
+}
+
+<div class="ui negative message">
+    <div class="header">
+        @Model.Translate(GeneralStrings.Error)
+    </div>
+    <p style="white-space: pre-line">@error</p>
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
@@ -11,7 +11,7 @@
     <div class="digits" id="2fa">
         @if (!string.IsNullOrWhiteSpace(error))
         {
-            @await Html.PartialAsync("Partials/ErrorModalPartial", ((string)Model.Translate(GeneralStrings.Error), (string)Model.Error), ViewData)
+            @await Html.PartialAsync("Partials/ErrorModalPartial", ((string)Model.Translate(GeneralStrings.Error), error), ViewData)
         }
         <input type="text" pattern="\d*" maxlength="1" id="digit1"/>
         <input type="text" pattern="\d*" maxlength="1" id="digit2"/>
@@ -41,15 +41,15 @@
 @if (allowBackupCodes)
 {
     <text>
-document.getElementById("backup-link").addEventListener("click", function (){
-    let backupInput = document.getElementById("backup"); 
-    if (backupInput.style.display === "none"){
-        backupInput.style.display = "";
-    } else {
-        backupInput.style.display = "none";
-    }
-});
-</text>
+        document.getElementById("backup-link").addEventListener("click", function (){
+            let backupInput = document.getElementById("backup"); 
+            if (backupInput.style.display === "none"){
+                backupInput.style.display = "";
+            } else {
+                backupInput.style.display = "none";
+            }
+        });
+    </text>
 }
 
 document.querySelector(".digits").addEventListener("keydown", function(event){

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
@@ -10,14 +10,14 @@
     @Html.AntiForgeryToken()
     <div class="digits" id="2fa">
         @if (!string.IsNullOrWhiteSpace(error))
-            {
-                <div class="ui negative message">
-                    <div class="header">
-                        @Model.Translate(GeneralStrings.Error)
-                    </div>
-                    <p style="white-space: pre-line">@Model.Error</p>
-                </div>
-            }
+        {
+            @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
+                   {
+                       {
+                           "Error", Model.Error
+                       },
+                   })
+        }
         <input type="text" pattern="\d*" maxlength="1" id="digit1"/>
         <input type="text" pattern="\d*" maxlength="1" id="digit2"/>
         <input type="text" pattern="\d*" maxlength="1" id="digit3" class="middleDigit"/>
@@ -45,7 +45,7 @@
 
 @if (allowBackupCodes)
 {
-<text>
+    <text>
 document.getElementById("backup-link").addEventListener("click", function (){
     let backupInput = document.getElementById("backup"); 
     if (backupInput.style.display === "none"){

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
@@ -11,12 +11,7 @@
     <div class="digits" id="2fa">
         @if (!string.IsNullOrWhiteSpace(error))
         {
-            @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
-                   {
-                       {
-                           "Error", error
-                       },
-                   })
+            @await Html.PartialAsync("Partials/ErrorModalPartial", ((string)Model.Translate(GeneralStrings.Error), (string)Model.Error), ViewData)
         }
         <input type="text" pattern="\d*" maxlength="1" id="digit1"/>
         <input type="text" pattern="\d*" maxlength="1" id="digit2"/>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/TwoFactorPartial.cshtml
@@ -14,7 +14,7 @@
             @await Html.PartialAsync("Partials/ErrorModalPartial", new ViewDataDictionary(ViewData)
                    {
                        {
-                           "Error", Model.Error
+                           "Error", error
                        },
                    })
         }


### PR DESCRIPTION
As suggested in https://github.com/LBPUnion/ProjectLighthouse/pull/781#discussion_r1218575630, this PR refactors the commonly used error modal into it's own partial to prevent duplicate code.

Recommended usage for this modal:
```cs
@if (!string.IsNullOrWhiteSpace(Model.Error))
{
    @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
}
```
