### PR TITLE
Bump Selenium.WebDriver from 4.9.1 to 4.10.0

### DIFF
--- a/ProjectLighthouse.Tests.WebsiteTests/ProjectLighthouse.Tests.WebsiteTests.csproj
+++ b/ProjectLighthouse.Tests.WebsiteTests/ProjectLighthouse.Tests.WebsiteTests.csproj
@@ -15,7 +15,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-        <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+        <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
         <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="113.0.5672.6300" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Manually bumping Selenium.WebDriver to 4.10.0 because Dependabot was having some issues with status checks.