### PR TITLE
Add online users endpoint to user API

### DIFF
--- a/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
@@ -130,10 +130,8 @@ public class UserEndpoints : ApiEndpointController
     /// </summary>
     /// <returns>Array of online users ordered by login time</returns>
     /// <response code="200">List of users</response>
-    /// <response code="404">No users were online</response>
     [HttpGet("users/online")]
     [ProducesResponseType(typeof(ApiUser), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetOnlineUsers()
     {
         List<ApiUser> onlineUsers = (await this.database.Users
@@ -142,7 +140,6 @@ public class UserEndpoints : ApiEndpointController
             .Where(u => u.GetStatus(this.database).StatusType == StatusType.Online)
             .OrderByDescending(u => u.LastLogin)
             .ToListAsync()).ToSerializableList(ApiUser.CreateFromEntity);
-        if (!onlineUsers.Any()) return this.NotFound();
 
         return this.Ok(onlineUsers);
     }

--- a/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
@@ -138,7 +138,8 @@ public class UserEndpoints : ApiEndpointController
             .Where(u => u.PermissionLevel != PermissionLevel.Banned)
             .Where(u => u.ProfileVisibility == PrivacyType.All)
             .Where(u => u.GetStatus(this.database).StatusType == StatusType.Online)
-            .OrderByDescending(u => u.LastLogin)
+            .OrderBy(u => u.LastLogin)
+            .Take(50)
             .ToListAsync()).ToSerializableList(ApiUser.CreateFromEntity);
 
         return this.Ok(onlineUsers);

--- a/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
@@ -142,7 +142,7 @@ public class UserEndpoints : ApiEndpointController
             .Where(u => u.PermissionLevel != PermissionLevel.Banned)
             .Where(u => u.ProfileVisibility == PrivacyType.All)
             .Where(u => u.GetStatus(this.database).StatusType == StatusType.Online)
-            .OrderBy(u => u.LastLogin)
+            .OrderByDescending(u => u.LastLogin)
             .Skip(page * clamp)
             .Take(clamp)
             .ToListAsync()).ToSerializableList(ApiUser.CreateFromEntity);

--- a/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
@@ -136,7 +136,8 @@ public class UserEndpoints : ApiEndpointController
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetOnlineUsers()
     {
-        List<ApiUser> onlineUsers = (await this.database.Users.Where(u => u.PermissionLevel != PermissionLevel.Banned)
+        List<ApiUser> onlineUsers = (await this.database.Users
+            .Where(u => u.PermissionLevel != PermissionLevel.Banned)
             .Where(u => u.ProfileVisibility == PrivacyType.All)
             .Where(u => u.GetStatus(this.database).StatusType == StatusType.Online)
             .OrderByDescending(u => u.LastLogin)


### PR DESCRIPTION
This PR adds an endpoint which lists all currently online users by their login time. This could be useful for services that want to deal with all currently online users at once but don't want to use some other inefficient method of obtaining the users.