### PR TITLE
Allow moderators to moderate story levels

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
@@ -94,7 +94,7 @@ public class CommentController : ControllerBase
             .ApplyPagination(pageData)
             .ToListAsync()).ToSerializableList(c => GameComment.CreateFromEntity(c, token.UserId));
 
-        if (type == CommentType.Level && slotType == "developer" && user.IsModerator)
+        if (type == CommentType.Level && slotType == "developer" && user.IsModerator && pageData.PageStart == 1)
         {
             comments.Insert(0, new GameComment
             {

--- a/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
@@ -50,7 +50,12 @@ public class CommentController : ControllerBase
     {
         GameTokenEntity token = this.GetToken();
 
+        UserEntity? user = await this.database.UserFromGameToken(token);
+        if (user == null) return this.Unauthorized();
+
         if ((slotId == 0 || SlotHelper.IsTypeInvalid(slotType)) == (username == null)) return this.BadRequest();
+
+        int originalSlotId = slotId;
 
         if (slotType == "developer") slotId = await SlotHelper.GetPlaceholderSlotId(this.database, slotId, SlotType.Developer);
 
@@ -88,6 +93,17 @@ public class CommentController : ControllerBase
             .Where(p => p.Poster.PermissionLevel != PermissionLevel.Banned)
             .ApplyPagination(pageData)
             .ToListAsync()).ToSerializableList(c => GameComment.CreateFromEntity(c, token.UserId));
+
+        if (type == CommentType.Level && slotType == "developer" && user.IsModerator)
+        {
+            comments.Insert(0, new GameComment
+            {
+                CommentId = 0,
+                Timestamp = 0,
+                AuthorUsername = "LH",
+                Message = $"Slot ID: {targetId}, Story level ID: {originalSlotId}",
+            });
+        }
 
         return this.Ok(new CommentListResponse(comments));
     }

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationPageController.cs
@@ -1,0 +1,35 @@
+﻿using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using LBPUnion.ProjectLighthouse.Types.Levels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Controllers.Moderator;
+
+[ApiController]
+[Route("moderation")]
+public class ModerationPageController : ControllerBase
+{
+    private readonly DatabaseContext database;
+
+    public ModerationPageController(DatabaseContext database)
+    {
+        this.database = database;
+    }
+
+    [HttpPost("findStoryLevel")]
+    public async Task<IActionResult> FindStorySlot([FromForm] int placeholderSlotId)
+    {
+        UserEntity? user = this.database.UserFromWebRequest(this.Request);
+        if (user == null) return this.Redirect("~/login");
+
+        if (!user.IsModerator) return this.Redirect("~/");
+
+        int slotId = await this.database.Slots.Where(s => s.Type == SlotType.Developer)
+            .Where(s => s.InternalSlotId == placeholderSlotId)
+            .Select(s => s.SlotId)
+            .FirstOrDefaultAsync();
+
+        return this.Redirect(slotId == 0 ? "~/" : $"~/slot/{slotId}");
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Moderation/ModPanelPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Moderation/ModPanelPage.cshtml
@@ -51,3 +51,14 @@ else
     <i class="globe americas icon"></i>
     <span>View hidden levels</span>
 </a>
+
+<div class="ui divider"></div>
+<form method="post" action="/moderation/findStoryLevel">
+    @Html.AntiForgeryToken()
+    <div class="ui left action input">
+        <button type="submit" class="ui blue button">
+            <span>Find Story Level</span>
+        </button>
+        <input type="text" name="placeholderSlotId" placeholder="Level ID">
+    </div>
+</form>

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
@@ -29,7 +29,7 @@ public class SlotPage : BaseLayout
     public async Task<IActionResult> OnGet([FromRoute] int id)
     {
         SlotEntity? slot = await this.Database.Slots.Include(s => s.Creator)
-            .Where(s => s.Type == SlotType.User)
+            .Where(s => s.Type == SlotType.User || (this.User != null && this.User.PermissionLevel >= PermissionLevel.Moderator))
             .FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.NotFound();
         System.Diagnostics.Debug.Assert(slot.Creator != null);

--- a/ProjectLighthouse/Types/Serialization/GameComment.cs
+++ b/ProjectLighthouse/Types/Serialization/GameComment.cs
@@ -53,6 +53,8 @@ public class GameComment : ILbpSerializable, INeedsPreparationForSerialization
 
     public async Task PrepareSerialization(DatabaseContext database)
     {
+        if (this.CommentId == 0 || this.PosterUserId == 0) return;
+
         this.AuthorUsername = await database.Users.Where(u => u.UserId == this.PosterUserId)
             .Select(u => u.Username)
             .FirstOrDefaultAsync();


### PR DESCRIPTION
The primary reason for this PR is currently it isn't really possible for mods to delete abusive comments or scores on story levels.

This PR adds an extra comment on story levels that shows the story levels ID and slot ID. This comment only displays to moderators and will always be at the top of the comments. This is so that mods can easily find the story level id that a bad score/comment is on.
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/4ce190d5-7f1d-4cd9-9250-3ff1cb6f2f10)

The mod panel on the website has a new form that lets people easily put in a story level ID and be redirected to the slot page.
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/4703d2b8-85e0-4afb-a0a2-ce6d4a2e4f71)

Then finally, mods are now able to directly access story levels on the website, it looks something like this:
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/566819ec-a6b7-4163-bc27-bf2805dc5b30)