### PR TITLE
Optimize GameServer /announce and add website announcements

### DIFF
--- a/ProjectLighthouse.Localization/General.resx
+++ b/ProjectLighthouse.Localization/General.resx
@@ -57,4 +57,7 @@
     <data name="email" xml:space="preserve">
         <value>Email</value>
     </data>
+    <data name="announcements" xml:space="preserve">
+        <value>Announcements</value>
+    </data>
 </root>

--- a/ProjectLighthouse.Localization/StringLists/GeneralStrings.cs
+++ b/ProjectLighthouse.Localization/StringLists/GeneralStrings.cs
@@ -15,6 +15,7 @@ public static class GeneralStrings
     public static readonly TranslatableString RecentPhotos = create("recent_photos");
     public static readonly TranslatableString RecentActivity = create("recent_activity");
     public static readonly TranslatableString Soon = create("soon");
+    public static readonly TranslatableString Announcements = create("announcements");
     
     private static TranslatableString create(string key) => new(TranslationAreas.General, key);
 }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Text;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
@@ -51,25 +52,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
 
         string username = await this.database.UsernameFromGameToken(token);
 
-        string announceText = ServerConfiguration.Instance.AnnounceText;
+        StringBuilder announceText = new(ServerConfiguration.Instance.AnnounceText);
 
-        announceText = announceText.Replace("%user", username);
-        announceText = announceText.Replace("%id", token.UserId.ToString());
+        announceText.Replace("%user", username);
+        announceText.Replace("%id", token.UserId.ToString());
 
-        return this.Ok
-        (
-            announceText +
-            #if DEBUG
-            "\n\n---DEBUG INFO---\n" +
-            $"user.UserId: {token.UserId}\n" +
-            $"token.UserLocation: {token.UserLocation}\n" +
-            $"token.GameVersion: {token.GameVersion}\n" +
-            $"token.TicketHash: {token.TicketHash}\n" +
-            $"token.ExpiresAt: {token.ExpiresAt.ToString()}\n" +
-            "---DEBUG INFO---" +
-            #endif
-            (string.IsNullOrWhiteSpace(announceText) ? "" : "\n")
-        );
+        #if DEBUG
+        announceText.Append("\n\n---DEBUG INFO---\n" +
+                                  $"user.UserId: {token.UserId}\n" +
+                                  $"token.UserLocation: {token.UserLocation}\n" +
+                                  $"token.GameVersion: {token.GameVersion}\n" +
+                                  $"token.TicketHash: {token.TicketHash}\n" +
+                                  $"token.ExpiresAt: {token.ExpiresAt.ToString()}\n" +
+                                  "---DEBUG INFO---");
+        #endif
+        
+        return this.Ok(announceText);
     }
 
     [HttpGet("notification")]

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -67,7 +67,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
                                   "---DEBUG INFO---");
         #endif
         
-        return this.Ok(announceText);
+        return this.Ok(announceText.ToString());
     }
 
     [HttpGet("notification")]

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -32,27 +32,37 @@
     </div>
 }
 
-@foreach (WebsiteAnnouncementEntity announcement in Model.Announcements)
+@if (Model.Announcements.Any())
+{
+    @foreach (WebsiteAnnouncementEntity announcement in Model.Announcements)
+    {
+        <div class="ui blue segment" style="position: relative;">
+            <h3>@announcement.Title</h3>
+            <p style="white-space: initial;">
+                @announcement.Content
+            </p>
+
+            @if (Model.User != null && Model.User.IsAdmin)
+            {
+                <form method="post">
+                    @Html.AntiForgeryToken()
+                    <button
+                        asp-page-handler="delete"
+                        asp-route-id="@announcement.Identifier"
+                        onclick="return confirm('Are you sure you want to delete this announcement?')"
+                        class="ui red icon button"
+                        style="position: absolute;
+                    right: 0.5em; top: 0.5em">
+                        <i class="trash icon"></i>
+                    </button>
+                </form>
+            }
+        </div>
+    }    
+}
+else
 {
     <div class="ui blue segment" style="position: relative;">
-        <h3>@announcement.Title</h3>
-        <p style="white-space: initial;">
-            @announcement.Content
-        </p>
-        @if (Model.User != null && Model.User.IsAdmin)
-        {
-            <form method="post">
-                @Html.AntiForgeryToken()
-                <button
-                    asp-page-handler="delete"
-                    asp-route-id="@announcement.Identifier"
-                    onclick="return confirm('Are you sure you want to delete this announcement?')"
-                    class="ui red icon button"
-                    style="position: absolute;
-                    right: 0.5em; top: 0.5em">
-                    <i class="trash icon"></i>
-                </button>
-            </form>
-        }
+        <p>There are no announcements to display.</p>
     </div>
 }

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -1,0 +1,58 @@
+﻿@page "/announce"
+@using LBPUnion.ProjectLighthouse.Localization.StringLists
+@using LBPUnion.ProjectLighthouse.Types.Entities.Website
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.AnnouncePage
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+@{
+    Layout = "Layouts/BaseLayout";
+    Model.Title = Model.Translate(GeneralStrings.Announcements);
+}
+
+@if (Model.User != null && Model.User.IsAdmin)
+{
+    <div class="ui red segment">
+        <h3>Post New Announcement</h3>
+        @if (!string.IsNullOrWhiteSpace(Model.Error))
+        {
+            @await Html.PartialAsync("Partials/ErrorModalPartial", (Model.Translate(GeneralStrings.Error), Model.Error), ViewData)
+        }
+        <form id="form" method="POST" class="ui form center aligned" action="/announce">
+            @Html.AntiForgeryToken()
+            <div class="field">
+                <label style="text-align: left" for="title">Announcement Title</label>
+                <input type="text" name="title" id="title">
+            </div>
+            <div class="field">
+                <label style="text-align: left" for="content">Announcement Content</label>
+                <input type="text" name="content" id="content">
+            </div>
+            <button class="ui button green" type="submit" tabindex="0">Save Changes</button>
+        </form>
+    </div>
+}
+
+@foreach (WebsiteAnnouncementEntity announcement in Model.Announcements)
+{
+    <div class="ui blue segment" style="position: relative;">
+        <h3>@announcement.Title</h3>
+        <p style="white-space: initial;">
+            @announcement.Content
+        </p>
+        @if (Model.User != null && Model.User.IsAdmin)
+        {
+            <form method="post">
+                @Html.AntiForgeryToken()
+                <button
+                    asp-page-handler="delete"
+                    asp-route-id="@announcement.Identifier"
+                    onclick="return confirm('Are you sure you want to delete this announcement?')"
+                    class="ui red icon button"
+                    style="position: absolute;
+                    right: 0.5em; top: 0.5em">
+                    <i class="trash icon"></i>
+                </button>
+            </form>
+        }
+    </div>
+}

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -51,8 +51,7 @@
                         asp-route-id="@announcement.AnnouncementId"
                         onclick="return confirm('Are you sure you want to delete this announcement?')"
                         class="ui red icon button"
-                        style="position: absolute;
-                    right: 0.5em; top: 0.5em">
+                        style="position: absolute; right: 0.5em; top: 0.5em">
                         <i class="trash icon"></i>
                     </button>
                 </form>

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -25,7 +25,7 @@
             </div>
             <div class="field">
                 <label style="text-align: left" for="content">Announcement Content</label>
-                <input type="text" name="content" id="content">
+                <textarea name="content" id="content" spellcheck="false"></textarea>
             </div>
             <button class="ui button green" type="submit" tabindex="0">Save Changes</button>
         </form>

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -48,7 +48,7 @@
                     @Html.AntiForgeryToken()
                     <button
                         asp-page-handler="delete"
-                        asp-route-id="@announcement.Identifier"
+                        asp-route-id="@announcement.AnnouncementId"
                         onclick="return confirm('Are you sure you want to delete this announcement?')"
                         class="ui red icon button"
                         style="position: absolute;

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -27,7 +27,7 @@
                 <label style="text-align: left" for="content">Announcement Content</label>
                 <textarea name="content" id="content" spellcheck="false"></textarea>
             </div>
-            <button class="ui button green" type="submit" tabindex="0">Save Changes</button>
+            <button class="ui button green" type="submit" tabindex="0">Post Announcement</button>
         </form>
     </div>
 }

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml
@@ -25,7 +25,7 @@
             </div>
             <div class="field">
                 <label style="text-align: left" for="content">Announcement Content</label>
-                <textarea name="content" id="content" spellcheck="false"></textarea>
+                <textarea name="content" id="content" spellcheck="false" rows="3"></textarea>
             </div>
             <button class="ui button green" type="submit" tabindex="0">Post Announcement</button>
         </form>

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 
+using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Website;
@@ -46,6 +48,16 @@ public class AnnouncePage : BaseLayout
 
         await this.Database.WebsiteAnnouncements.AddAsync(announcement);
         await this.Database.SaveChangesAsync();
+
+        if (DiscordConfiguration.Instance.DiscordIntegrationEnabled)
+        {
+            string truncatedAnnouncement = content.Length > 100 ? content[..100] + "..." : content;
+            
+            await WebhookHelper.SendWebhook(
+                title: "A new announcement has been posted",
+                description: $"{truncatedAnnouncement} [read more]({ServerConfiguration.Instance.ExternalUrl}/announce)",
+                dest: WebhookHelper.WebhookDestination.Public);    
+        }
 
         return this.RedirectToPage();
     }

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
@@ -22,7 +22,7 @@ public class AnnouncePage : BaseLayout
     public async Task<IActionResult> OnGet()
     {
         this.Announcements = await this.Database.WebsiteAnnouncements
-            .OrderByDescending(a => a.Identifier)
+            .OrderByDescending(a => a.AnnouncementId)
             .ToListAsync();
 
         return this.Page();
@@ -69,7 +69,7 @@ public class AnnouncePage : BaseLayout
         if (!user.IsAdmin) return this.BadRequest();
 
         WebsiteAnnouncementEntity? announcement = await this.Database.WebsiteAnnouncements
-            .Where(a => a.Identifier == id)
+            .Where(a => a.AnnouncementId == id)
             .FirstOrDefaultAsync();
 
         if (announcement == null) return this.BadRequest();

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
@@ -51,12 +51,12 @@ public class AnnouncePage : BaseLayout
 
         if (DiscordConfiguration.Instance.DiscordIntegrationEnabled)
         {
-            string truncatedAnnouncement = content.Length > 250 ? content[..250] + "..." : content;
-            
-            await WebhookHelper.SendWebhook(
-                title: "A new announcement has been posted",
-                description: $"{truncatedAnnouncement} ([read more]({ServerConfiguration.Instance.ExternalUrl}/announce))",
-                dest: WebhookHelper.WebhookDestination.Public);    
+            string truncatedAnnouncement = content.Length > 250
+                ? content[..250] + $"... [read more]({ServerConfiguration.Instance.ExternalUrl}/announce)"
+                : content;
+
+            await WebhookHelper.SendWebhook($":mega: {title}",
+                truncatedAnnouncement);
         }
 
         return this.RedirectToPage();

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
@@ -51,11 +51,11 @@ public class AnnouncePage : BaseLayout
 
         if (DiscordConfiguration.Instance.DiscordIntegrationEnabled)
         {
-            string truncatedAnnouncement = content.Length > 100 ? content[..100] + "..." : content;
+            string truncatedAnnouncement = content.Length > 250 ? content[..250] + "..." : content;
             
             await WebhookHelper.SendWebhook(
                 title: "A new announcement has been posted",
-                description: $"{truncatedAnnouncement} [read more]({ServerConfiguration.Instance.ExternalUrl}/announce)",
+                description: $"{truncatedAnnouncement} ([read more]({ServerConfiguration.Instance.ExternalUrl}/announce))",
                 dest: WebhookHelper.WebhookDestination.Public);    
         }
 

--- a/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/AnnouncePage.cshtml.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using LBPUnion.ProjectLighthouse.Types.Entities.Website;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages;
+
+public class AnnouncePage : BaseLayout
+{
+    public AnnouncePage(DatabaseContext database) : base(database)
+    { }
+
+    public List<WebsiteAnnouncementEntity> Announcements { get; set; } = new();
+    public string Error { get; set; } = "";
+
+    public async Task<IActionResult> OnGet()
+    {
+        this.Announcements = await this.Database.WebsiteAnnouncements
+            .OrderByDescending(a => a.Identifier)
+            .ToListAsync();
+
+        return this.Page();
+    }
+
+    public async Task<IActionResult> OnPost([FromForm] string title, [FromForm] string content)
+    {
+        UserEntity? user = this.Database.UserFromWebRequest(this.Request);
+        if (user == null) return this.BadRequest();
+        if (!user.IsAdmin) return this.BadRequest();
+
+        if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(content))
+        {
+            this.Error = "Invalid form data, please ensure all fields are filled out.";
+            return this.Page();
+        }
+
+        WebsiteAnnouncementEntity announcement = new()
+        {
+            Title = title,
+            Content = content,
+        };
+
+        await this.Database.WebsiteAnnouncements.AddAsync(announcement);
+        await this.Database.SaveChangesAsync();
+
+        return this.RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostDelete(int id)
+    {
+        UserEntity? user = this.Database.UserFromWebRequest(this.Request);
+        if (user == null) return this.BadRequest();
+        if (!user.IsAdmin) return this.BadRequest();
+
+        WebsiteAnnouncementEntity? announcement = await this.Database.WebsiteAnnouncements
+            .Where(a => a.Identifier == id)
+            .FirstOrDefaultAsync();
+
+        if (announcement == null) return this.BadRequest();
+
+        this.Database.WebsiteAnnouncements.Remove(announcement);
+        await this.Database.SaveChangesAsync();
+
+        return this.RedirectToPage();
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml.cs
@@ -33,6 +33,8 @@ public class BaseLayout : PageModel
         this.NavigationItems.Add(new PageNavigationItem(BaseLayoutStrings.HeaderUsers, "/users/0", "user friends"));
         this.NavigationItems.Add(new PageNavigationItem(BaseLayoutStrings.HeaderPhotos, "/photos/0", "camera"));
         this.NavigationItems.Add(new PageNavigationItem(BaseLayoutStrings.HeaderSlots, "/slots/0", "globe americas"));
+        
+        this.NavigationItemsRight.Add(new PageNavigationItem(GeneralStrings.Announcements, "/announce", "bullhorn"));
     }
 
     public new UserEntity? User {

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
@@ -82,12 +83,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
 
         ServerConfiguration.Instance.AnnounceText = "you are now logged in as %user (id: %id)";
 
-        const string expected = "you are now logged in as unittest (id: 1)\n";
+        const string expected = "you are now logged in as unittest (id: 1)";
 
         IActionResult result = await messageController.Announce();
 
-        string announceMsg = result.CastTo<OkObjectResult, string>();
-        Assert.Equal(expected, announceMsg);
+        StringBuilder announceMsg = result.CastTo<OkObjectResult, StringBuilder>();
+        Assert.Equal(expected, announceMsg.ToString());
     }
 
     [Fact]
@@ -103,8 +104,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
 
         IActionResult result = await messageController.Announce();
 
-        string announceMsg = result.CastTo<OkObjectResult, string>();
-        Assert.Equal(expected, announceMsg);
+        StringBuilder announceMsg = result.CastTo<OkObjectResult, StringBuilder>();
+        Assert.Equal(expected, announceMsg.ToString());
     }
 
     [Fact]

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
@@ -87,8 +86,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
 
         IActionResult result = await messageController.Announce();
 
-        StringBuilder announceMsg = result.CastTo<OkObjectResult, StringBuilder>();
-        Assert.Equal(expected, announceMsg.ToString());
+        string announceMsg = result.CastTo<OkObjectResult, string>();
+        Assert.Equal(expected, announceMsg);
     }
 
     [Fact]
@@ -104,8 +103,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
 
         IActionResult result = await messageController.Announce();
 
-        StringBuilder announceMsg = result.CastTo<OkObjectResult, StringBuilder>();
-        Assert.Equal(expected, announceMsg.ToString());
+        string announceMsg = result.CastTo<OkObjectResult, string>();
+        Assert.Equal(expected, announceMsg);
     }
 
     [Fact]

--- a/ProjectLighthouse.Tests.WebsiteTests/Integration/AdminTests.cs
+++ b/ProjectLighthouse.Tests.WebsiteTests/Integration/AdminTests.cs
@@ -14,7 +14,7 @@ namespace ProjectLighthouse.Tests.WebsiteTests.Integration;
 [Trait("Category", "Integration")]
 public class AdminTests : LighthouseWebTest
 {
-    private const string adminPanelButtonXPath = "/html/body/div/header/div/div/div/a[1]";
+    private const string adminPanelButtonXPath = "/html/body/div/header/div/div/div/a[2]";
 
     [Fact]
     public async Task ShouldShowAdminPanelButtonWhenAdmin()

--- a/ProjectLighthouse/Database/DatabaseContext.cs
+++ b/ProjectLighthouse/Database/DatabaseContext.cs
@@ -5,6 +5,7 @@ using LBPUnion.ProjectLighthouse.Types.Entities.Maintenance;
 using LBPUnion.ProjectLighthouse.Types.Entities.Moderation;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
+using LBPUnion.ProjectLighthouse.Types.Entities.Website;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Database;
@@ -60,6 +61,10 @@ public partial class DatabaseContext : DbContext
 
     #region Misc
     public DbSet<CompletedMigrationEntity> CompletedMigrations { get; set; }
+    #endregion
+    
+    #region Website
+    public DbSet<WebsiteAnnouncementEntity> WebsiteAnnouncements { get; set; }
     #endregion
 
     #endregion

--- a/ProjectLighthouse/Migrations/20230620211613_AddWebAnnouncementsToDb.cs
+++ b/ProjectLighthouse/Migrations/20230620211613_AddWebAnnouncementsToDb.cs
@@ -17,7 +17,7 @@ namespace ProjectLighthouse.Migrations
                 name: "WebsiteAnnouncements",
                 columns: table => new
                 {
-                    Identifier = table.Column<int>(
+                    AnnouncementId = table.Column<int>(
                             type: "int", 
                             nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
@@ -34,7 +34,7 @@ namespace ProjectLighthouse.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_WebsiteAnnouncements", x => x.Identifier);
+                    table.PrimaryKey("PK_WebsiteAnnouncements", x => x.AnnouncementId);
                 })
                 .Annotation("MySql:CharSet", "utf8mb4");
         }

--- a/ProjectLighthouse/Migrations/20230620211613_AddWebAnnouncementsToDb.cs
+++ b/ProjectLighthouse/Migrations/20230620211613_AddWebAnnouncementsToDb.cs
@@ -1,0 +1,48 @@
+﻿using LBPUnion.ProjectLighthouse.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectLighthouse.Migrations
+{
+    [DbContext(typeof(DatabaseContext))]
+    [Migration("20230620211613_AddWebAnnouncementsToDb")]
+    public partial class AddWebAnnouncementsToDb : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WebsiteAnnouncements",
+                columns: table => new
+                {
+                    Identifier = table.Column<int>(
+                            type: "int", 
+                            nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Title = table.Column<string>(
+                            type: "longtext", 
+                            nullable: false,
+                            defaultValue: "")
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Content = table.Column<string>(
+                            type: "longtext", 
+                            nullable: false,
+                            defaultValue: "")
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WebsiteAnnouncements", x => x.Identifier);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+        
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WebsiteAnnouncements");
+        }
+    }
+}

--- a/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -16,7 +16,7 @@ namespace ProjectLighthouse.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.4")
+                .HasAnnotation("ProductVersion", "7.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Interaction.HeartedLevelEntity", b =>
@@ -1022,6 +1022,23 @@ namespace ProjectLighthouse.Migrations
                     b.HasKey("TokenId");
 
                     b.ToTable("WebTokens");
+                });
+
+            modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Website.WebsiteAnnouncementEntity", b =>
+                {
+                    b.Property<int>("Identifier")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<string>("Content")
+                        .HasColumnType("longtext");
+
+                    b.Property<string>("Title")
+                        .HasColumnType("longtext");
+
+                    b.HasKey("Identifier");
+
+                    b.ToTable("WebsiteAnnouncements");
                 });
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Interaction.HeartedLevelEntity", b =>

--- a/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -1026,7 +1026,7 @@ namespace ProjectLighthouse.Migrations
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Website.WebsiteAnnouncementEntity", b =>
                 {
-                    b.Property<int>("Identifier")
+                    b.Property<int>("AnnouncementId")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 

--- a/ProjectLighthouse/Types/Entities/Website/WebsiteAnnouncementEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Website/WebsiteAnnouncementEntity.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace LBPUnion.ProjectLighthouse.Types.Entities.Website;
+
+public class WebsiteAnnouncementEntity
+{
+    [Key]
+    public int Identifier { get; set; }
+
+    public string Title { get; set; }
+
+    public string Content { get; set; }
+}

--- a/ProjectLighthouse/Types/Entities/Website/WebsiteAnnouncementEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Website/WebsiteAnnouncementEntity.cs
@@ -5,7 +5,7 @@ namespace LBPUnion.ProjectLighthouse.Types.Entities.Website;
 public class WebsiteAnnouncementEntity
 {
     [Key]
-    public int Identifier { get; set; }
+    public int AnnouncementId { get; set; }
 
     public string Title { get; set; }
 


### PR DESCRIPTION
This PR changes a few things pertaining to announcements.

* Implements a web-based announcements system
* Optimizes /announce to use a StringBuilder

First off, I improved the /announce game server endpoint in 144e952bde2bf80d0e8fb52212ec4c288091fa8b to use a string builder instead of re-assigning string modifications over and over again.

Second, I implemented a website-based announcements system in 4f89c10f1ccceb325a7dcc978c6ac41385ed3f37 which will allow instance administrators to send out announcements to users. I opted to condense the changes across several commits into one singular commit to improve organization.

Last, I added Discord webhook support in d5b773926eb9ff645bc39ca749e74dfb8d8c0bba which sends new announcements to the configured Discord webhook, if set up.

fdd6e2db2f224469d39e9d954e0e01af8c8626ae simply fixes a web display issue.

<details>
<summary>Images</summary>
<img width="1154" alt="Screenshot 2023-06-20 at 9 04 14 PM" src="https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/d2acaedc-fa8b-499b-a09d-e610def252b7">
<img width="1154" alt="Screenshot 2023-06-20 at 9 04 55 PM" src="https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/2c49820d-6061-4298-9263-e8f51bf31960">
</details>