### PR TITLE
Fix null case bug in BannedUserPage and properly add no expiration text

### DIFF
--- a/ProjectLighthouse.Localization/Moderation.resx
+++ b/ProjectLighthouse.Localization/Moderation.resx
@@ -37,7 +37,7 @@
         <value>LittleBigPlanet™ Online multiplayer</value>
     </data>
     <data name="does_not_expire" xml:space="preserve">
-        <value>Does not expire</value>
+        <value>manually dismissed</value>
     </data>
     <data name="profile_visibility" xml:space="preserve">
         <value>Profile visibility</value>

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -9,6 +9,8 @@
 
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
     TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
+
+    DateTime maximumExpiration = new(9999, 12, 31, 11, 59, 00, DateTimeKind.Utc);
 }
 
 <div class="ui middle aligned left aligned">
@@ -20,7 +22,7 @@
         @if (Model.ModCase != null)
         {
             <span>
-                @if (Model.ModCase.ExpiresAt != null)
+                @if (Model.ModCase.ExpiresAt < maximumExpiration)
                 {
                     @Model.Translate(ModerationStrings.SuspensionExpiration, TimeZoneInfo.ConvertTime(Model.ModCase.ExpiresAt.Value, timeZoneInfo).ToString("M/d/yyyy @ h:mm tt"))
                 }
@@ -29,6 +31,12 @@
                     @Model.Translate(ModerationStrings.SuspensionExpiration, Model.Translate(ModerationStrings.DoesNotExpire))
                 }
             </span>    
+        }
+        else
+        {
+            <span>
+                @Model.Translate(ModerationStrings.SuspensionExpiration, Model.Translate(GeneralStrings.Unknown))
+            </span>
         }
 
         <ul>

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -1,6 +1,7 @@
 ﻿@page "/banned"
 @using LBPUnion.ProjectLighthouse.Configuration
 @using LBPUnion.ProjectLighthouse.Localization.StringLists
+@using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Login.BannedUserPage
 
 @{
@@ -9,8 +10,6 @@
 
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
     TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
-
-    DateTime maximumExpiration = new(9999, 12, 31, 23, 59, 00, DateTimeKind.Utc);
 }
 
 <div class="ui middle aligned left aligned">
@@ -22,7 +21,7 @@
         @if (Model.ModCase != null)
         {
             <span>
-                @if (Model.ModCase.ExpiresAt < maximumExpiration)
+                @if (Model.ModCase.ExpiresAt < BannedUserPage.MaximumExpiration)
                 {
                     @Model.Translate(ModerationStrings.SuspensionExpiration, TimeZoneInfo.ConvertTime(Model.ModCase.ExpiresAt.Value, timeZoneInfo).ToString("M/d/yyyy @ h:mm tt"))
                 }

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -10,7 +10,7 @@
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
     TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
 
-    DateTime maximumExpiration = new(9999, 12, 31, 11, 59, 00, DateTimeKind.Utc);
+    DateTime maximumExpiration = new(9999, 12, 31, 23, 59, 00, DateTimeKind.Utc);
 }
 
 <div class="ui middle aligned left aligned">

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -46,11 +46,18 @@
             <li>@Model.Translate(ModerationStrings.AccountProfileManagement)</li>
         </ul>
     </p>
-    
+
     @if (Model.ModCase != null)
     {
         <p>
-            @Model.Translate(ModerationStrings.SuspensionReason, Model.ModCase.Reason)
+            @if (!string.IsNullOrWhiteSpace(Model.ModCase.Reason))
+            {
+                @Model.Translate(ModerationStrings.SuspensionReason, Model.ModCase.Reason)    
+            }
+            else
+            {
+                @Model.Translate(ModerationStrings.SuspensionReason, "No reason was provided.")
+            }
         </p>     
     }
 

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml
@@ -38,14 +38,16 @@
                 @Model.Translate(ModerationStrings.SuspensionExpiration, Model.Translate(GeneralStrings.Unknown))
             </span>
         }
-
+    </p>
+    
+    <div>
         <ul>
             <li>@Model.Translate(ModerationStrings.LbpOnlineMultiplayer)</li>
             <li>@Model.Translate(ModerationStrings.WebsiteInteractions)</li>
             <li>@Model.Translate(ModerationStrings.ProfileVisibility)</li>
             <li>@Model.Translate(ModerationStrings.AccountProfileManagement)</li>
         </ul>
-    </p>
+    </div>
 
     @if (Model.ModCase != null)
     {

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
@@ -17,6 +17,14 @@ public class BannedUserPage : BaseLayout
     { }
 
     public ModerationCaseEntity? ModCase;
+    
+    /*
+     * Used for deciding when to show the permanent ban string rather than the expiration time
+     *
+     * The DateTime.MaxValue expression wouldn't work in this case because the it exceeds the
+     * maximum value the case creation form lets you enter.
+     */
+    public static DateTime MaximumExpiration { get; } = new(9999, 12, 31, 23, 59, 00, DateTimeKind.Utc);
 
     [UsedImplicitly]
     public async Task<IActionResult> OnGet()

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
@@ -34,7 +34,8 @@ public class BannedUserPage : BaseLayout
         if (user == null) return this.Redirect("~/login");
         if (!user.IsBanned) return this.Redirect("~/");
 
-        ModerationCaseEntity? modCase = await this.Database.Cases.OrderByDescending(c => c.CreatedAt)
+        ModerationCaseEntity? modCase = await this.Database.Cases
+            .OrderByDescending(c => c.CreatedAt)
             .Where(c => c.AffectedId == user.UserId)
             .Where(c => c.Type == CaseType.UserBan)
             .Where(c => c.ExpiresAt != null)

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
@@ -24,7 +24,7 @@ public class BannedUserPage : BaseLayout
      * The DateTime.MaxValue expression wouldn't work in this case because the it exceeds the
      * maximum value the case creation form lets you enter.
      */
-    public static DateTime MaximumExpiration { get; } = new(9999, 12, 31, 23, 59, 00, DateTimeKind.Utc);
+    public static DateTime MaximumExpiration => new(9999, 12, 31, 23, 59, 00, DateTimeKind.Utc);
 
     [UsedImplicitly]
     public async Task<IActionResult> OnGet()

--- a/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/BannedUserPage.cshtml.cs
@@ -29,7 +29,7 @@ public class BannedUserPage : BaseLayout
         ModerationCaseEntity? modCase = await this.Database.Cases.OrderByDescending(c => c.CreatedAt)
             .Where(c => c.AffectedId == user.UserId)
             .Where(c => c.Type == CaseType.UserBan)
-            .Where(c => c.DismissedAt != null)
+            .Where(c => c.ExpiresAt != null)
             .FirstOrDefaultAsync();
 
         if (modCase == null) Logger.Warn($"User {user.UserId} is banned but has no mod case?", LogArea.Login);


### PR DESCRIPTION
This PR fixes the issue where the ban information page would improperly pull the user's latest moderation case, pulling the latest dismissed case rather than the latest case where expiration isn't null (which should theoretically never happen anyways, but should still check since it is marked as nullable in the database).

Also properly implements the existing permanent ban string into the information page, as well as fixes a missing page element when the case is null.