### PR TITLE
Add the ability for moderators to forcibly lock levels

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -240,6 +240,12 @@ public class PublishController : ControllerBase
 
             oldSlot.MinimumPlayers = Math.Clamp(slot.MinimumPlayers, 1, 4);
             oldSlot.MaximumPlayers = Math.Clamp(slot.MaximumPlayers, 1, 4);
+            
+            // Check if the level has been locked by a moderator to avoid unlocking it
+            if (oldSlot.LockedByModerator)
+            {
+                oldSlot.InitiallyLocked = true;
+            }
 
             await this.database.SaveChangesAsync();
             return this.Ok(SlotBase.CreateFromEntity(oldSlot, token));

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -26,12 +26,40 @@
 @if (Model.Slot!.Hidden)
 {
     <div class="ui inverted red segment">
-        <h2>This level is currently hidden.</h2>
-        <p><b>Only you and moderators may view this level.</b></p>
-        
-        <b>Reason:</b> <span>"@Model.Slot.HiddenReason"</span>
-        
-        <p><b>For more information please contact a moderator.</b></p>
+        <h3 style="margin-bottom:5px;"><i class="ban icon"></i> This level is currently hidden.</h3>
+        @if (Model.User != null && Model.User.IsModerator)
+        {
+            <b>Reason:</b>
+            <span>"@Model.Slot.HiddenReason"</span>
+            <br/>
+            <p>
+                <i>Only you and other moderators may view the hidden reason.</i>
+            </p>
+        }
+        else
+        {
+            <p>This level has been hidden for violating the Terms of Service. Remember to follow the rules!</p>
+        }
+    </div>
+}
+
+@if (Model.Slot!.LockedByModerator)
+{
+    <div class="ui inverted red segment">
+        <h3 style="margin-bottom:5px;"><i class="lock icon"></i> This level has been locked by a moderator.</h3>
+        @if (Model.User != null && Model.User.IsModerator)
+        {
+            <b>Reason:</b>
+            <span>"@Model.Slot.LockedReason"</span>
+            <br/>
+            <p>
+                <i>Only you and other moderators may view the lock reason.</i>
+            </p>
+        }
+        else
+        {
+            <p>This level has been locked for violating the Terms of Service. Remember to follow the rules!</p>
+        }
     </div>
 }
 
@@ -204,6 +232,16 @@
                 <div class="ui yellow button">
                     <i class="lock icon"></i>
                     <span>Hide</span>
+                </div>
+            </a>
+        }
+        
+        @if (!Model.Slot!.LockedByModerator)
+        {
+            <a href="/moderation/newCase?type=@((int)CaseType.LevelLock)&affectedId=@Model.Slot?.SlotId">
+                <div class="ui yellow button">
+                    <i class="lock icon"></i>
+                    <span>Forcibly Lock Level</span>
                 </div>
             </a>
         }

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -236,7 +236,7 @@
             </a>
         }
         
-        @if (!Model.Slot!.LockedByModerator)
+        @if (!Model.Slot!.InitiallyLocked && !Model.Slot!.LockedByModerator)
         {
             <a href="/moderation/newCase?type=@((int)CaseType.LevelLock)&affectedId=@Model.Slot?.SlotId">
                 <div class="ui yellow button">

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -26,15 +26,11 @@
 @if (Model.Slot!.Hidden)
 {
     <div class="ui inverted red segment">
-        <h3 style="margin-bottom:5px;"><i class="ban icon"></i> This level is currently hidden.</h3>
+        <h3><i class="ban icon"></i> This level is currently hidden.</h3>
         @if (Model.User != null && Model.User.IsModerator)
         {
             <b>Reason:</b>
             <span>"@Model.Slot.HiddenReason"</span>
-            <br/>
-            <p>
-                <i>Only you and other moderators may view the hidden reason.</i>
-            </p>
         }
         else
         {
@@ -46,15 +42,11 @@
 @if (Model.Slot!.LockedByModerator)
 {
     <div class="ui inverted red segment">
-        <h3 style="margin-bottom:5px;"><i class="lock icon"></i> This level has been locked by a moderator.</h3>
+        <h3><i class="lock icon"></i> This level has been locked by a moderator.</h3>
         @if (Model.User != null && Model.User.IsModerator)
         {
             <b>Reason:</b>
             <span>"@Model.Slot.LockedReason"</span>
-            <br/>
-            <p>
-                <i>Only you and other moderators may view the lock reason.</i>
-            </p>
         }
         else
         {

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -23,14 +23,11 @@
 @if (Model.ProfileUser.IsBanned)
 {
     <div class="ui inverted red segment">
-        <h3 style="margin-bottom:5px;"><i class="ban icon"></i> This user is currently banned.</h3>
+        <h3><i class="ban icon"></i> This user is currently banned.</h3>
         @if (Model.User != null && Model.User.IsModerator)
         {
             <b>Reason:</b>
-            <span>"@Model.ProfileUser.BannedReason"</span> <br />
-            <p>
-                <i>Only you and other moderators may view the ban reason.</i>
-            </p>
+            <span>"@Model.ProfileUser.BannedReason"</span>
         }
         else 
         {

--- a/ProjectLighthouse/Administration/Maintenance/RepeatingTasks/PerformCaseActionsTask.cs
+++ b/ProjectLighthouse/Administration/Maintenance/RepeatingTasks/PerformCaseActionsTask.cs
@@ -77,6 +77,13 @@ public class PerformCaseActionsTask : IRepeatingTask
                         slot!.CommentsEnabled = true;
                         break;
                     }
+                    case CaseType.LevelLock:
+                    {
+                        slot!.InitiallyLocked = false;
+                        slot.LockedByModerator = false;
+                        slot.LockedReason = "";
+                        break;
+                    }
                     default: throw new ArgumentOutOfRangeException();
                 }
             }
@@ -119,6 +126,13 @@ public class PerformCaseActionsTask : IRepeatingTask
                     case CaseType.LevelDisableComments:
                     {
                         slot!.CommentsEnabled = false;
+                        break;
+                    }
+                    case CaseType.LevelLock:
+                    {
+                        slot!.InitiallyLocked = true;
+                        slot.LockedByModerator = true;
+                        slot.LockedReason = @case.Reason;
                         break;
                     }
                     default: throw new ArgumentOutOfRangeException();

--- a/ProjectLighthouse/Migrations/20230707125059_AddModerationLevelLocks.cs
+++ b/ProjectLighthouse/Migrations/20230707125059_AddModerationLevelLocks.cs
@@ -1,0 +1,41 @@
+﻿using LBPUnion.ProjectLighthouse.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectLighthouse.Migrations
+{
+    [DbContext(typeof(DatabaseContext))]
+    [Migration("20230707125059_AddModerationLevelLocks")]
+    public partial class AddModerationLevelLocks : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "LockedByModerator",
+                table: "Slots",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LockedReason",
+                table: "Slots",
+                type: "longtext",
+                nullable: false)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LockedByModerator",
+                table: "Slots");
+
+            migrationBuilder.DropColumn(
+                name: "LockedReason",
+                table: "Slots");
+        }
+    }
+}

--- a/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -16,7 +16,7 @@ namespace ProjectLighthouse.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.7")
+                .HasAnnotation("ProductVersion", "7.0.8")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Interaction.HeartedLevelEntity", b =>
@@ -405,6 +405,13 @@ namespace ProjectLighthouse.Migrations
 
                     b.Property<ulong>("LocationPacked")
                         .HasColumnType("bigint unsigned");
+
+                    b.Property<bool>("LockedByModerator")
+                        .HasColumnType("tinyint(1)");
+
+                    b.Property<string>("LockedReason")
+                        .IsRequired()
+                        .HasColumnType("longtext");
 
                     b.Property<int>("MaximumPlayers")
                         .HasColumnType("int");

--- a/ProjectLighthouse/Types/Entities/Level/SlotEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Level/SlotEntity.cs
@@ -66,6 +66,10 @@ public class SlotEntity
     public UserEntity? Creator { get; set; }
 
     public bool InitiallyLocked { get; set; }
+    
+    public bool LockedByModerator { get; set; }
+
+    public string LockedReason { get; set; } = "";
 
     public bool SubLevel { get; set; }
 

--- a/ProjectLighthouse/Types/Moderation/Cases/CaseType.cs
+++ b/ProjectLighthouse/Types/Moderation/Cases/CaseType.cs
@@ -5,7 +5,7 @@ using LBPUnion.ProjectLighthouse.Extensions;
 
 namespace LBPUnion.ProjectLighthouse.Types.Moderation.Cases;
 
-// Next available ID for use: 6
+// Next available ID for use: 7
 // PLEASE UPDATE THIS WHEN YOU ADD SOMETHING HERE!
 // IF YOU DO NOT ADD THIS IN ORDER PROPERLY THEN THERE WILL BE DATA CORRUPTION!
 // THE VALUE MUST ALWAYS BE EXPLICITLY SET.
@@ -18,6 +18,7 @@ public enum CaseType
     
     LevelHide = 4,
     LevelDisableComments = 5,
+    LevelLock = 6,
 }
 
 public static class CaseTypeExtensions
@@ -40,6 +41,7 @@ public static class CaseTypeExtensions
         {
             CaseType.LevelHide => true,
             CaseType.LevelDisableComments => true,
+            CaseType.LevelLock => true,
             _ => false,
         };
     }


### PR DESCRIPTION
This PR adds a new mod case type which allows moderators to forcibly lock levels. Forcibly locking a level sets the level's InitiallyLocked variable, as well as the reason for the lock. It also sets the LockedByModerator variable, which is checked upon re-publish to make sure the user cannot just unlock the level.

<details>
<summary>Images</summary>
<br>

![image](https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/b078fafa-c8f4-46e8-840d-c99e7067343e)
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/261a76b5-1ba9-43b1-b50b-0a7d7564d335)

</details>