### PR TITLE
Refactor profile and slot pages to use iFrames for pagination

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
@@ -81,10 +81,7 @@ public class CommentController : ControllerBase
 
         if (targetId == 0) return this.NotFound();
 
-        List<int> blockedUsers =  await (
-                from blockedProfile in this.database.BlockedProfiles
-                where blockedProfile.UserId == token.UserId
-                select blockedProfile.BlockedUserId).ToListAsync();
+        List<int> blockedUsers = await this.database.GetBlockedUsers(token.UserId);
 
         List<GameComment> comments = (await this.database.Comments.Where(p => p.TargetId == targetId && p.Type == type)
             .OrderByDescending(p => p.Timestamp)

--- a/ProjectLighthouse.Servers.Website/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/CommentController.cs
@@ -1,0 +1,82 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using LBPUnion.ProjectLighthouse.Types.Entities.Token;
+using LBPUnion.ProjectLighthouse.Types.Logging;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Controllers;
+
+[Route("{type}/{id:int}")]
+public class CommentController : ControllerBase
+{
+    private readonly DatabaseContext database;
+
+    public CommentController(DatabaseContext database)
+    {
+        this.database = database;
+    }
+
+    private static CommentType? ParseType(string type) =>
+        type switch
+        {
+            "slot" => CommentType.Level,
+            "user" => CommentType.Profile,
+            _ => null,
+        };
+
+    [HttpGet("rateComment")]
+    public async Task<IActionResult> RateComment(string type, int id, [FromQuery] int? commentId, [FromQuery] int? rating, [FromQuery] string? redirect)
+    {
+        WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
+        if (token == null) return this.Redirect("~/login");
+
+        CommentType? commentType = ParseType(type);
+        if (commentType == null) return this.BadRequest();
+
+        await this.database.RateComment(token.UserId, commentId.GetValueOrDefault(), rating.GetValueOrDefault());
+
+        return this.Redirect(redirect ?? $"~/user/{id}#{commentId}");
+    }
+
+    [HttpPost("postComment")]
+    public async Task<IActionResult> PostComment(string type, int id, [FromForm] string? msg, [FromQuery] string? redirect)
+    {
+        WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
+        if (token == null) return this.Redirect("~/login");
+
+        CommentType? commentType = ParseType(type);
+        if (commentType == null) return this.BadRequest();
+
+        if (msg == null)
+        {
+            Logger.Error($"Refusing to post comment from {token.UserId} on {commentType} {id}, {nameof(msg)} is null",
+                LogArea.Comments);
+            return this.Redirect("~/user/" + id);
+        }
+
+        string username = await this.database.UsernameFromWebToken(token);
+        string filteredText = CensorHelper.FilterMessage(msg);
+
+        if (ServerConfiguration.Instance.LogChatFiltering && filteredText != msg)
+            Logger.Info(
+                $"Censored profane word(s) from {commentType} comment sent by {username}: \"{msg}\" => \"{filteredText}\"",
+                LogArea.Filter);
+
+        bool success = await this.database.PostComment(token.UserId, id, (CommentType)commentType, filteredText);
+        if (success)
+        {
+            Logger.Success($"Posted comment from {username}: \"{filteredText}\" on {commentType} {id}",
+                LogArea.Comments);
+        }
+        else
+        {
+            Logger.Error($"Failed to post comment from {username}: \"{filteredText}\" on {commentType} {id}",
+                LogArea.Comments);
+        }
+
+        return this.Redirect(redirect ?? $"~/{type}/" + id);
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
@@ -46,49 +46,6 @@ public class SlotPageController : ControllerBase
         return this.Redirect("~/slots/0");
     }
 
-    [HttpGet("rateComment")]
-    public async Task<IActionResult> RateComment([FromRoute] int id, [FromQuery] int commentId, [FromQuery] int rating)
-    {
-        WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
-        if (token == null) return this.Redirect("~/login");
-
-        await this.database.RateComment(token.UserId, commentId, rating);
-
-        return this.Redirect($"~/slot/{id}#{commentId}");
-    }
-
-    [HttpPost("postComment")]
-    public async Task<IActionResult> PostComment([FromRoute] int id, [FromForm] string? msg)
-    {
-        WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
-        if (token == null) return this.Redirect("~/login");
-
-        if (msg == null)
-        {
-            Logger.Error($"Refusing to post comment from {token.UserId} on level {id}, {nameof(msg)} is null", LogArea.Comments);
-            return this.Redirect("~/slot/" + id);
-        }
-
-        string username = await this.database.UsernameFromWebToken(token);
-        string filteredText = CensorHelper.FilterMessage(msg);
-
-        if (ServerConfiguration.Instance.LogChatFiltering && filteredText != msg)
-            Logger.Info($"Censored profane word(s) from slot comment sent by {username}: \"{msg}\" => \"{filteredText}\"",
-                LogArea.Filter);
-
-        bool success = await this.database.PostComment(token.UserId, id, CommentType.Level, filteredText);
-        if (success)
-        {
-            Logger.Success($"Posted comment from {username}: \"{filteredText}\" on level {id}", LogArea.Comments);
-        }
-        else
-        {
-            Logger.Error($"Failed to post comment from {username}: \"{filteredText}\" on level {id}", LogArea.Comments);
-        }
-
-        return this.Redirect("~/slot/" + id);
-    }
-
     [HttpGet("heart")]
     public async Task<IActionResult> HeartLevel([FromRoute] int id, [FromQuery] string? callbackUrl)
     {

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml
@@ -4,23 +4,36 @@
 
 @{
     Model.Title = "Comments";
-    Layout = "Layouts/BaseFrame";
+    Layout = "PaginatedFrame";
 
     string language = Model.GetLanguage();
     string timeZone = Model.GetTimeZone();
-    string type = (string?)RouteData.Values["type"] ?? "";
-    _ = int.TryParse((string?)RouteData.Values["id"], out int id);
 }
 
-@await Html.PartialAsync("Partials/CommentsPartial", new ViewDataDictionary(ViewData.WithLang(language).WithTime(timeZone))
-       {
-           {
-               "PageOwner", Model.PageOwner
-           },
-           {
-               "BaseUrl", $"/{type}/{id}"
-           },
-           {
-               "RedirectUrl", $"/comments/{type}/{id}"
-           },
-       })
+<div class="ui yellow segment" id="comments">
+    @if (Model.Comments.Count == 0 && Model.CommentsEnabled)
+    {
+        <p>There are no comments.</p>
+    }
+    else if (!Model.CommentsEnabled)
+    {
+        <i>Comments are disabled.</i>
+    }
+    else
+    {
+        int count = Model.TotalItems;
+        <p>There @(count == 1 ? "is" : "are") @count comment@(count == 1 ? "" : "s").</p>
+        @await Html.PartialAsync("Partials/CommentsPartial", (Model.User, Model.Comments, Model.CommentsEnabled), new ViewDataDictionary(ViewData.WithLang(language).WithTime(timeZone))
+               {
+                   {
+                       "PageOwner", Model.PageOwner
+                   },
+                   {
+                       "BaseUrl", $"/{Model.Type}/{Model.Id}"
+                   },
+                   {
+                       "RedirectUrl", $"/comments/{Model.Type}/{Model.Id}"
+                   },
+               })
+    }
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml
@@ -1,0 +1,26 @@
+@page "/comments/{type}/{id:int}"
+@using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.CommentFrame
+
+@{
+    Model.Title = "Comments";
+    Layout = "Layouts/BaseFrame";
+
+    string language = Model.GetLanguage();
+    string timeZone = Model.GetTimeZone();
+    string type = (string?)RouteData.Values["type"] ?? "";
+    _ = int.TryParse((string?)RouteData.Values["id"], out int id);
+}
+
+@await Html.PartialAsync("Partials/CommentsPartial", new ViewDataDictionary(ViewData.WithLang(language).WithTime(timeZone))
+       {
+           {
+               "PageOwner", Model.PageOwner
+           },
+           {
+               "BaseUrl", $"/{type}/{id}"
+           },
+           {
+               "RedirectUrl", $"/comments/{type}/{id}"
+           },
+       })

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml.cs
@@ -1,0 +1,89 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using LBPUnion.ProjectLighthouse.Types.Users;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public class CommentFrame : BaseFrame
+{
+    public CommentFrame(DatabaseContext database) : base(database)
+    { }
+
+    public Dictionary<CommentEntity, RatedCommentEntity?> Comments = new();
+
+    public bool CommentsEnabled { get; set; }
+
+    public int PageOwner { get; set; }
+
+    public async Task<IActionResult> OnGet(string type, int id)
+    {
+        CommentType? commentType = type switch
+        {
+            "slot" => CommentType.Level,
+            "user" => CommentType.Profile,
+            _ => null,
+        };
+        switch (commentType)
+        {
+            case CommentType.Level:
+            {
+                this.CommentsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelCommentsEnabled;
+                SlotEntity? slot = await this.Database.Slots.FindAsync(id);
+                if (slot == null) return this.BadRequest();
+                this.PageOwner = slot.CreatorId;
+                this.CommentsEnabled &= slot.CommentsEnabled;
+                break;
+            }
+            case CommentType.Profile:
+            {
+                this.CommentsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelCommentsEnabled;
+                UserEntity? user = await this.Database.Users.FindAsync(id);
+                if (user == null) return this.BadRequest();
+                this.PageOwner = user.UserId;
+                this.CommentsEnabled &= user.CommentsEnabled;
+                break;
+            }
+            default: return this.BadRequest();
+        }
+
+        if (this.CommentsEnabled)
+        {
+            List<int> blockedUsers = this.User == null
+                ? new List<int>()
+                : await (
+                    from blockedProfile in this.Database.BlockedProfiles
+                    where blockedProfile.UserId == this.User.UserId
+                    select blockedProfile.BlockedUserId).ToListAsync();
+
+            this.Comments = await this.Database.Comments.Include(p => p.Poster)
+                .OrderByDescending(p => p.Timestamp)
+                .Where(c => c.TargetId == id && c.Type == commentType)
+                .Where(c => !blockedUsers.Contains(c.PosterUserId))
+                .Include(c => c.Poster)
+                .Where(c => c.Poster.PermissionLevel != PermissionLevel.Banned)
+                .Take(50)
+                .ToDictionaryAsync(c => c, _ => (RatedCommentEntity?)null);
+
+            if (this.User == null) return this.Page();
+
+            foreach (KeyValuePair<CommentEntity, RatedCommentEntity?> kvp in this.Comments)
+            {
+                RatedCommentEntity? reaction = await this.Database.RatedComments.FirstOrDefaultAsync(r =>
+                    r.UserId == this.User.UserId && r.CommentId == kvp.Key.CommentId);
+                this.Comments[kvp.Key] = reaction;
+            }
+        }
+        else
+        {
+            this.Comments = new Dictionary<CommentEntity, RatedCommentEntity?>();
+        }
+
+        return this.Page();
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/CommentFrame.cshtml.cs
@@ -88,6 +88,7 @@ public class CommentFrame : PaginatedFrame
         }
         else
         {
+            this.ClampPage();
             this.Comments = new Dictionary<CommentEntity, RatedCommentEntity?>();
         }
 

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
@@ -18,14 +18,22 @@
     @RenderBody()
 
     <div>
+        @{
+            string? url = Url.RouteUrl(ViewContext.RouteData.Values);
+        }
+         ]
         @if (Model.CurrentPage > 1)
         {
-            <a href="@Url.RouteUrl(ViewContext.RouteData.Values)?page=@(Model.CurrentPage - 1)">Previous Page</a>
+            <a href="@url?page=1">First Page</a>
+            <text> | </text>
+            <a href="@url?page=@(Model.CurrentPage - 1)">Previous Page</a>
         }
         Page @Model.CurrentPage / @Model.TotalPages
         @if (Model.CurrentPage < Model.TotalPages)
         {
-            <a href="@Url.RouteUrl(ViewContext.RouteData.Values)?page=@(Model.CurrentPage + 1)">Next Page</a>
+            <a href="@url?page=@(Model.CurrentPage + 1)">Next Page</a>
+            <text> | </text>
+            <a href="@url?page=@Model.TotalPages">Last Page</a>
         }
     </div>
 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
@@ -1,0 +1,33 @@
+@using LBPUnion.ProjectLighthouse.Extensions
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.PaginatedFrame
+
+<!DOCTYPE html>
+
+@{
+    Model.IsMobile = Model.Request.IsMobile();
+}
+
+<html lang="en">
+<head>
+    <title>@Model.Title</title>
+    <link rel="stylesheet" type="text/css" href="~/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="~/css/semantic.min.css">
+</head>
+<body>
+<div>
+    @RenderBody()
+
+    <div>
+        @if (Model.CurrentPage > 1)
+        {
+            <a href="@Url.RouteUrl(ViewContext.RouteData.Values)?page=@(Model.CurrentPage - 1)">Previous Page</a>
+        }
+        Page @Model.CurrentPage / @Model.TotalPages
+        @if (Model.CurrentPage < Model.TotalPages)
+        {
+            <a href="@Url.RouteUrl(ViewContext.RouteData.Values)?page=@(Model.CurrentPage + 1)">Next Page</a>
+        }
+    </div>
+</div>
+</body>
+</html>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml
@@ -21,7 +21,7 @@
         @{
             string? url = Url.RouteUrl(ViewContext.RouteData.Values);
         }
-         ]
+
         @if (Model.CurrentPage > 1)
         {
             <a href="@url?page=1">First Page</a>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
@@ -12,14 +12,14 @@ public abstract class PaginatedFrame : BaseFrame
     public int CurrentPage { get; set; }
     public int TotalItems { get; set; }
     public int ItemsPerPage { get; set; }
-    public int TotalPages => Math.Max(1, this.TotalItems / this.ItemsPerPage);
+    public int TotalPages => Math.Max(1, (int)Math.Ceiling(this.TotalItems / (float)this.ItemsPerPage));
 
     public PaginationData PageData =>
         new()
         {
             MaxElements = this.ItemsPerPage,
             PageSize = this.ItemsPerPage,
-            PageStart = this.CurrentPage,
+            PageStart = this.CurrentPage * this.ItemsPerPage,
             TotalElements = this.TotalItems,
         };
 

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
@@ -19,7 +19,7 @@ public abstract class PaginatedFrame : BaseFrame
         {
             MaxElements = this.ItemsPerPage,
             PageSize = this.ItemsPerPage,
-            PageStart = this.CurrentPage * this.ItemsPerPage,
+            PageStart = (this.CurrentPage - 1) * this.ItemsPerPage,
             TotalElements = this.TotalItems,
         };
 

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PaginatedFrame.cshtml.cs
@@ -1,0 +1,30 @@
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types.Filter;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public abstract class PaginatedFrame : BaseFrame
+{
+    protected PaginatedFrame(DatabaseContext database) : base(database)
+    { }
+
+    public int CurrentPage { get; set; }
+    public int TotalItems { get; set; }
+    public int ItemsPerPage { get; set; }
+    public int TotalPages => Math.Max(1, this.TotalItems / this.ItemsPerPage);
+
+    public PaginationData PageData =>
+        new()
+        {
+            MaxElements = this.ItemsPerPage,
+            PageSize = this.ItemsPerPage,
+            PageStart = this.CurrentPage,
+            TotalElements = this.TotalItems,
+        };
+
+    /// <summary>
+    /// Only call after setting CurrentPage and TotalItems
+    /// </summary>
+    public void ClampPage() => this.CurrentPage = Math.Clamp(this.CurrentPage, 1, this.TotalPages);
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml
@@ -4,7 +4,7 @@
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.PhotoFrame
 
 @{
-    Layout = "Layouts/BaseFrame";
+    Layout = "PaginatedFrame";
     Model.Title = "Photos";
     string language = Model.GetLanguage();
     string timeZone = Model.GetTimeZone();
@@ -12,7 +12,6 @@
 }
 
 <div class="ui purple segment" id="photos">
-
     @if (Model.Photos.Count > 0)
     {
         <div class="ui center aligned grid">
@@ -32,6 +31,6 @@
     }
     else
     {
-        <p>This user hasn't uploaded any photos</p>
+        <p>There are no photos</p>
     }
 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml
@@ -1,0 +1,37 @@
+@page "/photos/{type}/{id:int}"
+@using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
+@using LBPUnion.ProjectLighthouse.Types.Entities.Profile
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.PhotoFrame
+
+@{
+    Layout = "Layouts/BaseFrame";
+    Model.Title = "Photos";
+    string language = Model.GetLanguage();
+    string timeZone = Model.GetTimeZone();
+    bool isMobile = Model.IsMobile;
+}
+
+<div class="ui purple segment" id="photos">
+
+    @if (Model.Photos.Count > 0)
+    {
+        <div class="ui center aligned grid">
+            @foreach (PhotoEntity photo in Model.Photos)
+            {
+                string width = isMobile ? "sixteen" : "eight";
+                bool canDelete = Model.User != null && (Model.User.IsModerator || Model.User.UserId == photo.CreatorId);
+                <div class="@width wide column">
+                    @await photo.ToHtml(Html, ViewData, language, timeZone, canDelete)
+                </div>
+            }
+        </div>
+        @if (isMobile)
+        {
+            <br/>
+        }
+    }
+    else
+    {
+        <p>This user hasn't uploaded any photos</p>
+    }
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/PhotoFrame.cshtml.cs
@@ -1,0 +1,40 @@
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public class PhotoFrame : BaseFrame
+{
+    public List<PhotoEntity> Photos { get; set; } = new();
+
+    public PhotoFrame(DatabaseContext database) : base(database)
+    { }
+
+    public async Task<IActionResult> OnGet(string type, int id)
+    {
+        if (type != "user" && type != "slot") return this.BadRequest();
+
+        IQueryable<PhotoEntity> photoQuery = this.Database.Photos.Include(p => p.Slot)
+            .Include(p => p.PhotoSubjects)
+            .ThenInclude(ps => ps.User)
+            .OrderByDescending(p => p.Timestamp);
+
+        switch (type)
+        {
+            case "user":
+                photoQuery = photoQuery.Where(p => p.CreatorId == id);
+                break;
+            
+            case "slot":
+                photoQuery = photoQuery.Where(p => p.SlotId == id);
+                break;
+        }
+
+        this.Photos = await photoQuery.Take(6).ToListAsync();
+
+        return this.Page();
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml
@@ -1,0 +1,35 @@
+@page "/reviews/{slotId:int}"
+@using LBPUnion.ProjectLighthouse.Extensions
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.ReviewFrame
+
+@{
+    Layout = "PaginatedFrame";
+}
+
+<div class="ui purple segment">
+    @if (Model.Reviews.Count == 0 && Model.ReviewsEnabled)
+    {
+        <p>There are no reviews.</p>
+    }
+    else if (!Model.ReviewsEnabled)
+    {
+        <b>
+            <i>Reviews are disabled on this level.</i>
+        </b>
+    }
+    else
+    {
+        int count = Model.TotalItems;
+        <p>There @(count == 1 ? "is" : "are") @count review@(count == 1 ? "" : "s").</p>
+        <div class="ui divider"></div>
+        @await Html.PartialAsync("Partials/ReviewPartial", Model.Reviews, new ViewDataDictionary(ViewData)
+               {
+                   {
+                       "isMobile", Request.IsMobile()
+                   },
+                   {
+                       "CanDelete", Model.User?.IsModerator ?? false
+                   },
+               })
+    }
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml.cs
@@ -1,0 +1,50 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using LBPUnion.ProjectLighthouse.Types.Users;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public class ReviewFrame : PaginatedFrame
+{
+    public List<ReviewEntity> Reviews = new();
+
+    public bool ReviewsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelReviewsEnabled;
+
+    public ReviewFrame(DatabaseContext database) : base(database)
+    {
+        this.ItemsPerPage = 10;
+    }
+
+    public async Task<IActionResult> OnGet([FromQuery] int page, int slotId)
+    {
+        this.CurrentPage = page;
+
+        SlotEntity? slot = await this.Database.Slots.FindAsync(slotId);
+        if (slot == null) return this.BadRequest();
+
+        if (!this.ReviewsEnabled) return this.Page();
+
+        List<int> blockedUsers = await this.Database.GetBlockedUsers(this.User?.UserId);
+
+        IQueryable<ReviewEntity> reviewQuery = this.Database.Reviews.Where(r => r.SlotId == slotId)
+            .Where(r => !blockedUsers.Contains(r.ReviewerId))
+            .Include(r => r.Reviewer)
+            .Where(r => r.Reviewer.PermissionLevel != PermissionLevel.Banned);
+
+        this.TotalItems = await reviewQuery.CountAsync();
+
+        this.ClampPage();
+
+        this.Reviews = await reviewQuery.OrderByDescending(r => r.ThumbsUp - r.ThumbsDown)
+            .ThenByDescending(r => r.Timestamp)
+            .ApplyPagination(this.PageData)
+            .ToListAsync();
+
+        return this.Page();
+    }
+
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/ReviewFrame.cshtml.cs
@@ -26,7 +26,11 @@ public class ReviewFrame : PaginatedFrame
         SlotEntity? slot = await this.Database.Slots.FindAsync(slotId);
         if (slot == null) return this.BadRequest();
 
-        if (!this.ReviewsEnabled) return this.Page();
+        if (!this.ReviewsEnabled)
+        {
+            this.ClampPage();
+            return this.Page();
+        }
 
         List<int> blockedUsers = await this.Database.GetBlockedUsers(this.User?.UserId);
 

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/ScoreFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/ScoreFrame.cshtml
@@ -1,0 +1,23 @@
+@page "/scores/{slotId:int}/{scoreType:int?}"  
+@using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.ScoreFrame
+
+@{
+    Layout = "PaginatedFrame";
+    string language = Model.GetLanguage();
+    string timeZone = Model.GetTimeZone();
+}
+
+<div class="ui blue segment" id="scores">
+    @if (Model.TotalItems == 0)
+    {
+        <p>There are no scores.</p>
+    }
+    else
+    {
+        int count = Model.TotalItems;
+        <p>There @(count == 1 ? "is" : "are") @count score@(count == 1 ? "" : "s").</p>
+        <div class="ui divider"></div>
+        @await Html.PartialAsync("Partials/LeaderboardPartial", (Model.Scores, Model.ScoreType), ViewData.WithLang(language).WithTime(timeZone).CanDelete(Model.User?.IsModerator ?? false))
+    }
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/ScoreFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/ScoreFrame.cshtml.cs
@@ -1,0 +1,60 @@
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public class ScoreFrame : PaginatedFrame
+{
+    public List<(int Rank, ScoreEntity Score)> Scores = new();
+
+    public int ScoreType { get; set; }
+
+    public ScoreFrame(DatabaseContext database) : base(database)
+    {
+        this.ItemsPerPage = 10;
+    }
+
+    public async Task<IActionResult> OnGet([FromQuery] int page, int slotId, int? scoreType)
+    {
+        this.CurrentPage = page;
+        SlotEntity? slot = await this.Database.Slots.FindAsync(slotId);
+        if (slot == null) return this.BadRequest();
+
+        scoreType ??= slot.LevelType switch
+        {
+            "versus" => 7,
+            _ => 1,
+        };
+
+        Func<int?, bool> isValidFunc = slot.LevelType switch
+        {
+            "versus" => type => type == 7,
+            _ => type => type is >= 1 and <= 4,
+        };
+
+        if (!isValidFunc(scoreType)) return this.BadRequest();
+
+        IQueryable<ScoreEntity> scoreQuery = this.Database.Scores.Where(s => s.SlotId == slotId)
+            .Where(s => s.Type == scoreType);
+
+        this.TotalItems = await scoreQuery.CountAsync();
+
+        this.ClampPage();
+
+        this.Scores = (await scoreQuery.OrderByDescending(s => s.Points)
+                .ThenBy(s => s.ScoreId)
+                .Select(s => new
+                {
+                    Rank = scoreQuery.Count(s2 => s2.Points > s.Points) + 1,
+                    Score = s,
+                })
+                .ApplyPagination(this.PageData)
+                .ToListAsync()).Select(s => (s.Rank, s.Score))
+            .ToList();
+
+        return this.Page();
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml
@@ -4,24 +4,26 @@
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.SlotsFrame
 
 @{
-    Layout = "Layouts/BaseFrame";
+    Layout = "PaginatedFrame";
     Model.Title = "Photos";
     string language = Model.GetLanguage();
     string timeZone = Model.GetTimeZone();
     bool isMobile = Model.IsMobile;
-    string route = (string?)RouteData.Values["route"] ?? "";
-    _ = int.TryParse((string?)RouteData.Values["id"], out int id);
 }
 
-<div class="ui green segment" id="levels">
+<div class="ui @Model.Color segment" id="levels">
     @if (Model.Slots.Count == 0)
     {
-        <p>This user hasn't published any levels</p>
+        <p>@Model.SlotsEmptyText</p>
     }
-    @foreach (SlotEntity slot in Model.Slots)
+    else
     {
-        <div class="ui segment">
-            @await slot.ToHtml(Html, ViewData, Model.User, $"~/slots/{route}/{id}", language, timeZone, isMobile, true)
-        </div>
+        <p>@Model.SlotsPresentText</p>
+        foreach (SlotEntity slot in Model.Slots)
+        {
+            <div class="ui segment">
+                @await slot.ToHtml(Html, ViewData, Model.User, $"~/slots/{Model.Type}/{Model.Id}", language, timeZone, isMobile, true)
+            </div>
+        }
     }
 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml
@@ -1,0 +1,27 @@
+@page "/slots/{route}/{id:int}"
+@using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
+@using LBPUnion.ProjectLighthouse.Types.Entities.Level
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames.SlotsFrame
+
+@{
+    Layout = "Layouts/BaseFrame";
+    Model.Title = "Photos";
+    string language = Model.GetLanguage();
+    string timeZone = Model.GetTimeZone();
+    bool isMobile = Model.IsMobile;
+    string route = (string?)RouteData.Values["route"] ?? "";
+    _ = int.TryParse((string?)RouteData.Values["id"], out int id);
+}
+
+<div class="ui green segment" id="levels">
+    @if (Model.Slots.Count == 0)
+    {
+        <p>This user hasn't published any levels</p>
+    }
+    @foreach (SlotEntity slot in Model.Slots)
+    {
+        <div class="ui segment">
+            @await slot.ToHtml(Html, ViewData, Model.User, $"~/slots/{route}/{id}", language, timeZone, isMobile, true)
+        </div>
+    }
+</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml.cs
@@ -1,0 +1,32 @@
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
+
+public class SlotsFrame : BaseFrame
+{
+    public List<SlotEntity> Slots = new();
+
+    public SlotsFrame(DatabaseContext database) : base(database)
+    { }
+
+    public async Task<IActionResult> OnGet(string route, int id)
+    {
+        IQueryable<SlotEntity> slotsQuery = this.Database.Slots.AsQueryable();
+
+        switch (route)
+        {
+            case "by":
+                slotsQuery = this.Database.Slots.Include(p => p.Creator)
+                    .OrderByDescending(s => s.LastUpdated)
+                    .Where(p => p.CreatorId == id);
+                break;
+        }
+
+        this.Slots = await slotsQuery.Take(10).ToListAsync();
+        return this.Page();
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Frames/SlotsFrame.cshtml.cs
@@ -1,32 +1,76 @@
 using LBPUnion.ProjectLighthouse.Database;
-using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Frames;
 
-public class SlotsFrame : BaseFrame
+public class SlotsFrame : PaginatedFrame
 {
     public List<SlotEntity> Slots = new();
 
-    public SlotsFrame(DatabaseContext database) : base(database)
-    { }
+    public string Type { get; set; } = "";
+    public int Id { get; set; }
+    public string Color { get; set; } = "";
+    public string SlotsPresentText { get; set; } = "";
+    public string SlotsEmptyText { get; set; } = "";
 
-    public async Task<IActionResult> OnGet(string route, int id)
+    public SlotsFrame(DatabaseContext database) : base(database)
     {
+        this.ItemsPerPage = 10;
+    }
+
+    public async Task<IActionResult> OnGet([FromQuery] int page, string route, int id)
+    {
+        this.Type = route;
+        this.Id = id;
+        this.CurrentPage = page;
         IQueryable<SlotEntity> slotsQuery = this.Database.Slots.AsQueryable();
 
         switch (route)
         {
             case "by":
                 slotsQuery = this.Database.Slots.Include(p => p.Creator)
-                    .OrderByDescending(s => s.LastUpdated)
-                    .Where(p => p.CreatorId == id);
+                    .Where(p => p.CreatorId == id)
+                    .OrderByDescending(s => s.LastUpdated);
+                this.Color = "green";
+                this.SlotsEmptyText = "This user hasn't published any levels";
+                this.SlotsPresentText = "This user has published {0} level{1}";
+                break;
+            case "hearted":
+                slotsQuery = this.Database.HeartedLevels.Where(h => h.UserId == id).
+                    OrderByDescending(h => h.HeartedLevelId)
+                    .Include(h => h.Slot)
+                    .Select(h => h.Slot);
+                this.Color = "pink";
+                this.SlotsEmptyText = "You haven't hearted any levels";
+                this.SlotsPresentText = "You have hearted {0} level{1}";
+                break;
+            case "queued":
+                slotsQuery = this.Database.QueuedLevels.Where(q => q.UserId == id)
+                    .OrderByDescending(q => q.QueuedLevelId)
+                    .Include(q => q.Slot)
+                    .Select(q => q.Slot);
+                this.Color = "yellow";
+                this.SlotsEmptyText = "You haven't queued any levels";
+                this.SlotsPresentText = "There are {0} level{1} in your queue";
                 break;
         }
 
-        this.Slots = await slotsQuery.Take(10).ToListAsync();
+        this.TotalItems = await slotsQuery.CountAsync();
+
+        this.ClampPage();
+
+        if (this.TotalItems != 0)
+        {
+            this.SlotsPresentText = string.Format(this.SlotsPresentText, this.TotalItems, this.TotalItems == 1 ? "" : "s");
+        }
+
+        this.Slots = await slotsQuery
+            .ApplyPagination(this.PageData)
+            .ToListAsync();
+
         return this.Page();
     }
 }

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div>
-       @RenderBody()
+    @RenderBody()
 </div>
 </body>
 </html>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml
@@ -1,0 +1,21 @@
+@using LBPUnion.ProjectLighthouse.Extensions
+@model LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts.BaseFrame
+
+<!DOCTYPE html>      
+
+@{
+    Model.IsMobile = Model.Request.IsMobile();
+}
+
+<html lang="en">
+<head>
+    <title>@Model.Title</title>         
+    <link rel="stylesheet" type="text/css" href="~/css/styles.css">
+    <link rel="stylesheet" type="text/css" href="~/css/semantic.min.css">
+</head>
+<body>
+<div>
+       @RenderBody()
+</div>
+</body>
+</html>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseFrame.cshtml.cs
@@ -1,0 +1,59 @@
+using LBPUnion.ProjectLighthouse.Configuration;
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Localization;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
+
+public class BaseFrame : PageModel
+{
+    public readonly DatabaseContext Database;
+
+    public BaseFrame(DatabaseContext database)
+    {
+        this.Database = database;
+    }
+
+    public string Title = string.Empty;
+    public bool IsMobile;
+
+    private UserEntity? user;
+    public new UserEntity? User
+    {
+        get
+        {
+            if (this.user != null) return this.user;
+
+            return this.user = this.Database.UserFromWebRequest(this.Request);
+        }
+        set => this.user = value;
+    }
+
+    private string? language;
+    private string? timeZone;
+
+    public string GetLanguage()
+    {
+        if (ServerStatics.IsUnitTesting) return LocalizationManager.DefaultLang;
+        if (this.language != null) return this.language;
+
+        if (this.User != null) return this.language = this.User.Language;
+
+        IRequestCultureFeature? requestCulture = this.Request.HttpContext.Features.Get<IRequestCultureFeature>();
+        if (requestCulture == null) return this.language = LocalizationManager.DefaultLang;
+
+        return this.language = requestCulture.RequestCulture.UICulture.Name;
+    }
+
+    public string GetTimeZone()
+    {
+        if (ServerStatics.IsUnitTesting) return TimeZoneInfo.Local.Id;
+        if (this.timeZone != null) return this.timeZone;
+
+        string userTimeZone = this.User?.TimeZone ?? TimeZoneInfo.Local.Id;
+
+        return this.timeZone = userTimeZone;
+    }
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -67,8 +67,12 @@
     @* If non-frame page is loaded in iFrame, redirect top level window *@
     <script>
         if (window.self !== window.top) {
+            console.log("referrer: " + document.referrer);
             console.log("we loaded in iframe");
-            window.top.location = window.location;
+            let locationHref = window.location.href;
+            location.replace(document.referrer);
+            
+            window.top.location.replace(locationHref);
         }
     </script>
 

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -70,7 +70,8 @@
             window.stop()
             let locationHref = window.location.href;
             location.replace(document.referrer);
-            
+            document.documentElement.style.display = "none";
+
             window.top.location.replace(locationHref);
         }
     </script>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -65,8 +65,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     @* If non-frame page is loaded in iFrame, redirect top level window *@
-    <script>
+    <script type="text/javascript">
         if (window.self !== window.top) {
+            window.stop()
             let locationHref = window.location.href;
             location.replace(document.referrer);
             

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -67,8 +67,6 @@
     @* If non-frame page is loaded in iFrame, redirect top level window *@
     <script>
         if (window.self !== window.top) {
-            console.log("referrer: " + document.referrer);
-            console.log("we loaded in iframe");
             let locationHref = window.location.href;
             location.replace(document.referrer);
             

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -63,6 +63,14 @@
     }
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    @* If non-frame page is loaded in iFrame, redirect top level window *@
+    <script>
+        if (window.self !== window.top) {
+            console.log("we loaded in iframe");
+            window.top.location = window.location;
+        }
+    </script>
 
     @* Google Analytics *@
     @if (ServerConfiguration.Instance.GoogleAnalytics.AnalyticsEnabled)

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -12,6 +12,8 @@
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
     TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
     int pageOwnerId = (int?)ViewData["PageOwner"] ?? 0;
+    string baseUrl = (string?)ViewData["BaseUrl"] ?? Url.RouteUrl(ViewContext.RouteData.Values) ?? "~/";
+    string? redirectUrl = (string?)ViewData["RedirectUrl"];
 }
 
 <div class="ui yellow segment" id="comments">
@@ -32,7 +34,8 @@
     @if (Model.CommentsEnabled && Model.User != null)
     {
         <div class="ui divider"></div>
-        <form class="ui reply form" action="@Url.RouteUrl(ViewContext.RouteData.Values)/postComment" method="post">
+
+        <form class="ui reply form" action="@baseUrl/postComment?redirect=@redirectUrl" method="post">
             <div class="field">
                 <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
             </div>
@@ -55,8 +58,6 @@
             HttpUtility.HtmlDecode(comment.GetCommentMessage(Database), messageWriter);
 
             string decodedMessage = messageWriter.ToString();
-            string? url = Url.RouteUrl(ViewContext.RouteData.Values);
-            if (url == null) continue;
 
             int rating = comment.ThumbsUp - comment.ThumbsDown;
 
@@ -69,11 +70,11 @@
                     }
                 }
                 <div class="voting" style="@(style)">
-                    <a href="@url/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == 1 ? 0 : 1)">
+                    <a href="@baseUrl/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == 1 ? 0 : 1)&redirect=@redirectUrl">
                         <i class="fitted @(yourThumb == 1 ? "green" : "grey") arrow up link icon" style="display: block"></i>
                     </a>
                     <span style="text-align: center; margin: auto; @(rating < 0 ? "margin-left: -5px" : "")">@(rating)</span>
-                    <a href="@url/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == -1 ? 0 : -1)">
+                    <a href="@baseUrl/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == -1 ? 0 : -1)&redirect=@redirectUrl">
                         <i class="fitted @(yourThumb == -1 ? "red" : "grey") arrow down link icon" style="display: block"></i>
                     </a>
                 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -5,8 +5,8 @@
 @using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
 @using LBPUnion.ProjectLighthouse.Types.Entities.Interaction
 @using LBPUnion.ProjectLighthouse.Types.Entities.Profile
+@model (UserEntity? User, Dictionary<CommentEntity, RatedCommentEntity?> Comments, bool CommentsEnabled)
 @inject DatabaseContext Database
-
 @{
     string language = (string?)ViewData["Language"] ?? LocalizationManager.DefaultLang;
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
@@ -16,100 +16,86 @@
     string? redirectUrl = (string?)ViewData["RedirectUrl"];
 }
 
-<div class="ui yellow segment" id="comments">
-    @if (Model.Comments.Count == 0 && Model.CommentsEnabled)
-    {
-        <p><i>There are no comments.</i></p>
-    }
-    else if (!Model.CommentsEnabled)
-    {
-        <p><i>Comments are disabled.</i></p>
-    }
-    else
-    {
-        int count = Model.Comments.Count;
-        <p>There @(count == 1 ? "is" : "are") @count comment@(count == 1 ? "" : "s").</p>
-    }
 
-    @if (Model.CommentsEnabled && Model.User != null)
+@if (Model.CommentsEnabled && Model.User != null)
+{
+    <div class="ui divider"></div>
+
+    <form class="ui reply form" action="@baseUrl/postComment?redirect=@redirectUrl" method="post">
+        <div class="field">
+            <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
+        </div>
+        <input type="submit" class="ui blue button">
+    </form>
+    @if (Model.Comments.Count > 0)
     {
         <div class="ui divider"></div>
-
-        <form class="ui reply form" action="@baseUrl/postComment?redirect=@redirectUrl" method="post">
-            <div class="field">
-                <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
-            </div>
-            <input type="submit" class="ui blue button">
-        </form>
-        @if (Model.Comments.Count > 0)
-        {
-            <div class="ui divider"></div>
-        }
     }
-    
-    @{
-        int i = 0;
-        foreach (KeyValuePair<CommentEntity, RatedCommentEntity?> commentAndReaction in Model.Comments)
-        {
-            CommentEntity comment = commentAndReaction.Key;
-            int yourThumb = commentAndReaction.Value?.Rating ?? 0;
-            DateTimeOffset timestamp = DateTimeOffset.FromUnixTimeSeconds(comment.Timestamp / 1000).ToLocalTime();
-            StringWriter messageWriter = new();
-            HttpUtility.HtmlDecode(comment.GetCommentMessage(Database), messageWriter);
+}
 
-            string decodedMessage = messageWriter.ToString();
+@{
+    int i = 0;
+    foreach ((CommentEntity? comment, RatedCommentEntity? value) in Model.Comments)
+    {
+        int yourThumb = value?.Rating ?? 0;
+        DateTimeOffset timestamp = DateTimeOffset.FromUnixTimeSeconds(comment.Timestamp / 1000).ToLocalTime();
+        StringWriter messageWriter = new();
+        HttpUtility.HtmlDecode(comment.GetCommentMessage(Database), messageWriter);
 
-            int rating = comment.ThumbsUp - comment.ThumbsDown;
+        string decodedMessage = messageWriter.ToString();
 
-            <div style="display: flex" id="@comment.CommentId">
-                @{
-                    string style = "";
-                    if (Model.User?.UserId == comment.PosterUserId)
-                    {
-                        style = "pointer-events: none";
-                    }
+        int rating = comment.ThumbsUp - comment.ThumbsDown;
+
+        <div style="display: flex" id="@comment.CommentId">
+            @{
+                string style = "";
+                if (Model.User?.UserId == comment.PosterUserId)
+                {
+                    style = "pointer-events: none";
                 }
-                <div class="voting" style="@(style)">
-                    <a href="@baseUrl/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == 1 ? 0 : 1)&redirect=@redirectUrl">
-                        <i class="fitted @(yourThumb == 1 ? "green" : "grey") arrow up link icon" style="display: block"></i>
-                    </a>
-                    <span style="text-align: center; margin: auto; @(rating < 0 ? "margin-left: -5px" : "")">@(rating)</span>
-                    <a href="@baseUrl/rateComment?commentId=@(comment.CommentId)&rating=@(yourThumb == -1 ? 0 : -1)&redirect=@redirectUrl">
-                        <i class="fitted @(yourThumb == -1 ? "red" : "grey") arrow down link icon" style="display: block"></i>
-                    </a>
-                </div>
+            }
 
-                <div class="comment">
-                    <b>@await comment.Poster.ToLink(Html, ViewData, language): </b>
-                    @if (comment.Deleted)
-                    {
-                        <i>
-                            <span>@decodedMessage</span>
-                        </i>
-                    }
-                    else
-                    {
-                        <span>@decodedMessage</span>
-                    }
-                    @if (((Model.User?.IsModerator ?? false) || Model.User?.UserId == comment.PosterUserId || Model.User?.UserId == pageOwnerId) && !comment.Deleted)
-                    {
-                        <button class="ui red icon button" style="display:inline-flex; float: right" onclick="deleteComment(@comment.CommentId)">
-                            <i class="trash icon"></i>
-                        </button>
-                    }
-                    <p>
-                        <i>@TimeZoneInfo.ConvertTime(timestamp, timeZoneInfo).ToString("M/d/yyyy @ h:mm:ss tt")</i>
-                    </p>
-                    @if (i != Model.Comments.Count - 1)
-                    {
-                        <div class="ui divider"></div>
-                    }
-                </div>
+            <div class="voting" style="@(style)">
+                <a href="@baseUrl/rateComment?commentId=@comment.CommentId&rating=@(yourThumb == 1 ? 0 : 1)&redirect=@redirectUrl">
+                    <i class="fitted @(yourThumb == 1 ? "green" : "grey") arrow up link icon" style="display: block"></i>
+                </a>
+                <span style="text-align: center; margin: auto; @(rating < 0 ? "margin-left: -5px" : "")">@(rating)</span>
+                <a href="@baseUrl/rateComment?commentId=@comment.CommentId&rating=@(yourThumb == -1 ? 0 : -1)&redirect=@redirectUrl">
+                    <i class="fitted @(yourThumb == -1 ? "red" : "grey") arrow down link icon" style="display: block"></i>
+                </a>
             </div>
-            i++;
-        }
+
+            <div class="comment">
+                <b>@await comment.Poster.ToLink(Html, ViewData, language): </b>
+                @if (comment.Deleted)
+                {
+                    <i>
+                        <span>@decodedMessage</span>
+                    </i>
+                }
+                else
+                {
+                    <span>@decodedMessage</span>
+                }
+                @if (((Model.User?.IsModerator ?? false) || Model.User?.UserId == comment.PosterUserId || Model.User?.UserId == pageOwnerId) && !comment.Deleted)
+                {
+                    <button class="ui red icon button" style="display:inline-flex; float: right" onclick="deleteComment(@comment.CommentId)">
+                        <i class="trash icon"></i>
+                    </button>
+                }
+                <p>
+                    <i>@TimeZoneInfo.ConvertTime(timestamp, timeZoneInfo).ToString("M/d/yyyy @ h:mm:ss tt")</i>
+                </p>
+                @if (i != Model.Comments.Count - 1)
+                {
+                    <div class="ui divider"></div>
+                }
+            </div>
+        </div>
+        i++;
     }
-    <script>
+}
+<script>
         function deleteComment(commentId){
             if (window.confirm("Are you sure you want to delete this?\nThis action cannot be undone.")){
                 window.location.hash = "comments";
@@ -117,4 +103,3 @@
             }
         }
     </script>
-</div>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
@@ -1,0 +1,9 @@
+@model (string Url, string Title)
+
+<iframe src="@Model.Url"
+        title="@Model.Title"
+        style="width: 100%; height: 100%; border: 0; overflow: hidden"
+        scrolling="no"
+        seamless="seamless"
+        onload="this.style.height=((this.contentWindow.document.body.scrollHeight) + 'px')">
+</iframe>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
@@ -5,5 +5,5 @@
         style="width: 100%; height: 100%; border: 0; overflow: hidden"
         scrolling="no"
         seamless="seamless"
-        onload="this.style.height=(this.contentWindow.document.querySelector('div').scrollHeight + 'px')">
+        onload="this.style.height=(this.contentWindow.document.querySelector('body').scrollHeight + 'px')">
 </iframe>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/FramePartial.cshtml
@@ -5,5 +5,5 @@
         style="width: 100%; height: 100%; border: 0; overflow: hidden"
         scrolling="no"
         seamless="seamless"
-        onload="this.style.height=((this.contentWindow.document.body.scrollHeight) + 'px')">
+        onload="this.style.height=(this.contentWindow.document.querySelector('div').scrollHeight + 'px')">
 </iframe>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/LeaderboardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/LeaderboardPartial.cshtml
@@ -4,44 +4,35 @@
 @using LBPUnion.ProjectLighthouse.Types.Entities.Level
 @using LBPUnion.ProjectLighthouse.Types.Entities.Profile
 @using Microsoft.EntityFrameworkCore
+@model (List<(int Rank, ScoreEntity Score)> Scores, int scoreType) 
+@inject DatabaseContext Database
 @{
     string language = (string?)ViewData["Language"] ?? LocalizationManager.DefaultLang;
     string timeZone = (string?)ViewData["TimeZone"] ?? TimeZoneInfo.Local.Id;
     bool canDelete = (bool?)ViewData["CanDelete"] ?? false;
-}
-<div class="ui blue segment" id="scores">
-    @if (Model.Scores.Count == 0)
+}          
+
+<div class="ui list">
+    @for (int i = 0; i < Model.Scores.Count; i++)
     {
-        <p>There are no scores.</p>
-    }
-    else
-    {
-        int count = Model.Scores.Count;
-        <p>There @(count == 1 ? "is" : "are") @count score@(count == 1 ? "" : "s").</p>
-        <div class="ui divider"></div>
-    }
-    <div class="ui list">
-    @for(int i = 0; i < Model.Scores.Count; i++)
-    {
-        ScoreEntity score = Model.Scores[i];
-        string[] playerIds = score.PlayerIds;
-        DatabaseContext database = Model.Database;          
+        (int Rank, ScoreEntity Score) scoreAndRank = Model.Scores[i];
+        string[] playerIds = scoreAndRank.Score.PlayerIds;
         <div class="item">
             <span class="ui large text">
-                @if(canDelete)
+                @if (canDelete)
                 {
-                    <button class="ui red icon button" style="display: inline-block; position: absolute; right: 1em" onclick="deleteScore(@score.ScoreId)">
+                    <button class="ui red icon button" style="display: inline-block; position: absolute; right: 1em" onclick="deleteScore(@scoreAndRank.Score.ScoreId)">
                         <i class="trash icon"></i>
-                    </button>            
-                }               
-                <b>@(i+1):</b>                 
-                <span class="ui text">@score.Points points</span>
+                    </button>
+                }
+                <b>@(scoreAndRank.Rank):</b>
+                <span class="ui text">@scoreAndRank.Score.Points points</span>
             </span>
             <div class="content">
                 <div class="list" style="padding-top: 0">
                     @for (int j = 0; j < playerIds.Length; j++)
                     {
-                        UserEntity? user = await database.Users.FirstOrDefaultAsync(u => u.Username == playerIds[j]);
+                        UserEntity? user = await Database.Users.FirstOrDefaultAsync(u => u.Username == playerIds[j]);
                         <div class="item">
                             <i class="minus icon" style="padding-top: 9px"></i>
                             <div class="content" style="padding-left: 0">
@@ -64,13 +55,12 @@
             <div class="ui divider"></div>
         }
     }
-    </div>
-    <script>
+</div>
+<script>
         function deleteScore(scoreId){
             if (window.confirm("Are you sure you want to delete this?\nThis action cannot be undone.")){
                 window.location.hash = "scores";
                 window.location.href = "/moderation/deleteScore/" + scoreId + "?callbackUrl=" + this.window.location;
             }
         }
-    </script>
-</div>
+</script>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
@@ -25,5 +25,4 @@
     {
         @Model.Username
     }
-
 </a>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
@@ -4,112 +4,94 @@
 @using LBPUnion.ProjectLighthouse.Helpers
 @using LBPUnion.ProjectLighthouse.Types.Entities.Level
 @using LBPUnion.ProjectLighthouse.Types.Serialization
+@model List<ReviewEntity>
 
 @{
     bool isMobile = (bool?)ViewData["IsMobile"] ?? false;
     bool canDelete = (bool?)ViewData["CanDelete"] ?? false;
 }
 
-<div class="eight wide column" id="reviews">
-        <div class="ui purple segment">
-            @if (Model.Reviews.Count == 0 && Model.ReviewsEnabled)
+@for (int i = 0; i < Model.Count; i++)
+{
+    ReviewEntity review = Model[i];
+    string faceHash = review.Thumb switch {
+        -1 => review.Reviewer?.BooHash,
+        0 => review.Reviewer?.MehHash,
+        1 => review.Reviewer?.YayHash,
+                    
+        _ => throw new ArgumentOutOfRangeException(),
+        } ?? "";
+
+    if (string.IsNullOrWhiteSpace(faceHash) || !FileHelper.ResourceExists(faceHash))
+    {
+        faceHash = ServerConfiguration.Instance.WebsiteConfiguration.MissingIconHash;
+    }
+
+    string faceAlt = review.Thumb switch {
+        -1 => "Boo!",
+        0 => "Meh.",
+        1 => "Yay!",
+                    
+        _ => throw new ArgumentOutOfRangeException(),
+        };
+
+    int size = isMobile ? 50 : 100;
+
+    <div class="card">
+        <div>
+            <img class="cardIcon slotCardIcon" src="@ServerConfiguration.Instance.ExternalUrl/gameAssets/@faceHash" alt="@faceAlt" title="@faceAlt" style="min-width: @(size)px; width: @(size)px; height: @(size)px">
+        </div>
+        <div class="cardStats">
+            <a href="/user/@review.Reviewer?.UserId">
+                <h3 style="margin-bottom: 5px;">@review.Reviewer?.Username</h3>
+            </a>
+            @if (review.Deleted)
             {
-                <p>There are no reviews.</p>
-            }
-            else if (!Model.ReviewsEnabled)
-            {
-                <b>
-                    <i>Reviews are disabled on this level.</i>
-                </b>
+                if (review.DeletedBy == DeletedBy.LevelAuthor)
+                {
+                    <p>
+                        <i>This review has been deleted by the level author.</i>
+                    </p>
+                }
+                else
+                {
+                    <p>
+                        <i>This review has been deleted by a moderator.</i>
+                    </p>
+                }
             }
             else
             {
-                int count = Model.Reviews.Count;
-                <p>There @(count == 1 ? "is" : "are") @count review@(count == 1 ? "" : "s").</p>
-                <div class="ui divider"></div>
-            }
-
-            @for(int i = 0; i < Model.Reviews.Count; i++)
-            {
-                ReviewEntity review = Model.Reviews[i];
-                string faceHash = (review.Thumb switch {
-                    -1 => review.Reviewer?.BooHash,
-                    0 => review.Reviewer?.MehHash,
-                    1 => review.Reviewer?.YayHash,
-                    
-                    _ => throw new ArgumentOutOfRangeException(),
-                    }) ?? "";
-
-                if (string.IsNullOrWhiteSpace(faceHash) || !FileHelper.ResourceExists(faceHash))
+                @if (review.Labels.Length > 1)
                 {
-                    faceHash = ServerConfiguration.Instance.WebsiteConfiguration.MissingIconHash;
+                    <div style="padding-bottom: 5px;">
+                        @foreach (string reviewLabel in review.Labels)
+                        {
+                            <div class="ui blue label">@LabelHelper.TranslateTag(reviewLabel)</div>
+                        }
+                    </div>
                 }
-
-                string faceAlt = review.Thumb switch {
-                    -1 => "Boo!",
-                    0 => "Meh.",
-                    1 => "Yay!",
-                    
-                    _ => throw new ArgumentOutOfRangeException(),
-                    };
-
-                int size = isMobile ? 50 : 100;
-
-                <div class="card">
-                    <div>
-                        <img class="cardIcon slotCardIcon" src="@ServerConfiguration.Instance.ExternalUrl/gameAssets/@faceHash" alt="@faceAlt" title="@faceAlt" style="min-width: @(size)px; width: @(size)px; height: @(size)px">
-                    </div>
-                    <div class="cardStats">
-                        <a href="/user/@review.Reviewer?.UserId">
-                            <h3 style="margin-bottom: 5px;">@review.Reviewer?.Username</h3>
-                        </a>
-                        @if (review.Deleted)
-                        {
-                            if (review.DeletedBy == DeletedBy.LevelAuthor)
-                            {
-                                <p>
-                                    <i>This review has been deleted by the level author.</i>
-                                </p>
-                            }
-                            else
-                            {
-                                <p>
-                                    <i>This review has been deleted by a moderator.</i>
-                                </p>
-                            }
-                        }
-                        else
-                        {
-                            @if (review.Labels.Length > 1)
-                            {
-                                <div style="padding-bottom: 5px;">
-                                    @foreach (string reviewLabel in review.Labels)
-                                    {
-                                        <div class="ui blue label">@LabelHelper.TranslateTag(reviewLabel)</div>
-                                    }
-                                </div>
-                            }
-                            @if (string.IsNullOrWhiteSpace(review.Text))
-                            {
-                                <p>
-                                    <i>This review contains no text.</i>
-                                </p>
-                            }
-                            else
-                            {
-                                {
-                                    <p>@HttpUtility.HtmlDecode(review.Text)</p>
-                                }
-                            }
-                        }
-                    </div>
-                    @if (canDelete && !review.Deleted)
+                @if (string.IsNullOrWhiteSpace(review.Text))
+                {
+                    <p>
+                        <i>This review contains no text.</i>
+                    </p>
+                }
+                else
+                {
                     {
-                        <div style="display: inline-block; right: 1em; position: absolute;">
-                        <button class="ui red icon button" onclick="deleteReview(@review.ReviewId)">
-                            <i class="trash icon"></i>
-                        </button>
-                            <script>
+                        <p>@HttpUtility.HtmlDecode(review.Text)</p>
+                    }
+                }
+            }
+        </div>
+        @if (canDelete && !review.Deleted)
+        {
+            <div style="display: inline-block; right: 1em; position: absolute;">
+                <button class="ui red icon button" onclick="deleteReview(@review.ReviewId)">
+                    <i class="trash icon"></i>
+                </button>
+                <script>
                             function deleteReview(reviewId){
                                 if (window.confirm("Are you sure you want to delete this?\nThis action cannot be undone.")){
                                     window.location.hash = "reviews";
@@ -117,17 +99,15 @@
                                 }          
                             }
                         </script>
-                        </div>
-                    }
-                </div>
-                @if (i != Model.Reviews.Count - 1)
-                {
-                    <div class="ui divider"></div>
-                }
-            }
-        </div>
-        @if (isMobile)
-        {
-            <br/>
+            </div>
         }
     </div>
+    @if (i != Model.Count - 1)
+    {
+        <div class="ui divider"></div>
+    }
+}
+@if (isMobile)
+{
+    <br/>
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
@@ -1,0 +1,51 @@
+<script>
+const sidebarElements = Array.from(document.querySelectorAll(".lh-sidebar"));
+const contentElements = Array.from(document.querySelectorAll(".lh-content"));
+let selectedId = window.location.hash;
+if (selectedId.startsWith("#"))
+    selectedId = selectedId.substring(1);
+let selectedElement = document.getElementById(selectedId);
+// id = lh-sidebar element
+function setVisible(e){
+    let eTarget = document.getElementById(e.target);
+    if (!e || !eTarget) return;
+
+    // make all active elements not active
+    for (let active of document.getElementsByClassName("active")) {
+        active.classList.remove("active");
+    }
+    // hide all content divs
+    for (let i = 0; i < contentElements.length; i++){
+        contentElements[i].style.display = "none";
+    }
+    // unhide content
+    eTarget.style.display = "";
+    let frame = eTarget.children[0] || undefined;
+    // set iframe height
+    if (frame !== undefined && frame.nodeName === "IFRAME"){
+        frame.style.height = (frame.contentWindow.document.body.scrollHeight+2) + "px"; 
+    }
+    
+    e.classList.add("active");
+}
+
+sidebarElements.forEach(el => {
+    if (el.classList.contains("active")){
+        setVisible(el);
+    }
+    el.addEventListener('click', event => {
+        if (!event.target.target) return;
+
+        setVisible(event.target)
+    })
+})
+// set the active content window based on url
+if (selectedElement != null) {
+    while (selectedElement != null && !selectedElement.classList.contains("lh-content")){
+        selectedElement = selectedElement.parentElement;
+    }
+    
+    let sidebarEle = document.querySelector("[target=" + selectedElement.id + "]")
+    setVisible(sidebarEle);
+}
+</script>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
@@ -20,10 +20,14 @@ function setVisible(e){
     }
     // unhide content
     eTarget.style.display = "";
+    
     let frame = eTarget.children[0] || undefined;
     // set iframe height
-    if (frame !== undefined && frame.nodeName === "IFRAME"){
-        frame.style.height = (frame.contentWindow.document.body.scrollHeight+2) + "px"; 
+    if (frame?.nodeName === "IFRAME"){
+        let mainDiv = frame.contentWindow.document.querySelector('div');
+        if (mainDiv != null){
+            frame.style.height = mainDiv.scrollHeight + "px";
+        } 
     }
     
     e.classList.add("active");

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SectionScriptPartial.cshtml
@@ -1,9 +1,11 @@
 <script>
 const sidebarElements = Array.from(document.querySelectorAll(".lh-sidebar"));
 const contentElements = Array.from(document.querySelectorAll(".lh-content"));
+
 let selectedId = window.location.hash;
-if (selectedId.startsWith("#"))
-    selectedId = selectedId.substring(1);
+if (selectedId.startsWith("#")) selectedId = selectedId.substring(1);
+if (!selectedId.startsWith("lh-")) selectedId = "lh-" + selectedId;
+
 let selectedElement = document.getElementById(selectedId);
 // id = lh-sidebar element
 function setVisible(e){
@@ -24,7 +26,7 @@ function setVisible(e){
     let frame = eTarget.children[0] || undefined;
     // set iframe height
     if (frame?.nodeName === "IFRAME"){
-        let mainDiv = frame.contentWindow.document.querySelector('div');
+        let mainDiv = frame.contentWindow.document.querySelector('body');
         if (mainDiv != null){
             frame.style.height = mainDiv.scrollHeight + "px";
         } 

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -114,13 +114,13 @@
         <div class="lh-content" id="lh-comments">
             @await Html.PartialAsync("Partials/FramePartial", ($"/comments/slot/{Model.Slot?.SlotId}", "Comments"))
         </div>
-        <div class="lh-content" id="lh-photos">
+        <div class="lh-content" id="lh-photos" style="display: none">
             @await Html.PartialAsync("Partials/FramePartial", ($"/photos/user/{Model.Slot?.SlotId}", "Photos"))
         </div>
-        <div class="lh-content" id="lh-reviews">
+        <div class="lh-content" id="lh-reviews" style="display: none">
             @await Html.PartialAsync("Partials/FramePartial", ($"/reviews/{Model.Slot?.SlotId}", "Reviews"))
         </div>
-        <div class="lh-content" id="lh-scores">
+        <div class="lh-content" id="lh-scores" style="display: none">
             @await Html.PartialAsync("Partials/FramePartial", ($"/scores/{Model.Slot?.SlotId}", "Scores"))
         </div>
     </div>

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -5,7 +5,6 @@
 @using LBPUnion.ProjectLighthouse.Helpers
 @using LBPUnion.ProjectLighthouse.Localization.StringLists
 @using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
-@using LBPUnion.ProjectLighthouse.Types.Entities.Profile
 @using LBPUnion.ProjectLighthouse.Types.Moderation.Cases
 @using LBPUnion.ProjectLighthouse.Types.Users
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.SlotPage
@@ -113,51 +112,16 @@
     }
     <div class="@divLength wide stretched column">
         <div class="lh-content" id="lh-comments">
-            @await Html.PartialAsync("Partials/CommentsPartial", new ViewDataDictionary(ViewData.WithLang(language).WithTime(timeZone))
-                   { { "PageOwner", Model.Slot?.CreatorId }, })
+            @await Html.PartialAsync("Partials/FramePartial", ($"/comments/slot/{Model.Slot?.SlotId}", "Comments"))
         </div>
         <div class="lh-content" id="lh-photos">
-            <div class="ui purple segment" id="photos">
-                @if (Model.Photos.Count != 0)
-                {
-                    <div class="ui center aligned grid">
-                        @foreach (PhotoEntity photo in Model.Photos)
-                        {
-                            string width = isMobile ? "sixteen" : "eight";
-                            bool canDelete = Model.User != null && (Model.User.IsModerator || Model.User.UserId == photo.CreatorId);
-                            <div class="@width wide column">
-                                @await photo.ToHtml(Html, ViewData, language, timeZone, canDelete)
-                            </div>
-                        }
-                    </div>
-                    @if (isMobile)
-                    {
-                        <br/>
-                    }
-                }
-                else
-                {
-                    <p>This level has no photos yet.</p>
-                }
-
-            </div>
+            @await Html.PartialAsync("Partials/FramePartial", ($"/photos/user/{Model.Slot?.SlotId}", "Photos"))
         </div>
         <div class="lh-content" id="lh-reviews">
-            @await Html.PartialAsync("Partials/ReviewPartial", new ViewDataDictionary(ViewData)
-                   {
-                       {
-                           "isMobile", isMobile
-                       },
-                       {
-                           "CanDelete", Model.User?.IsModerator ?? false
-                       },
-                   })
+            @await Html.PartialAsync("Partials/FramePartial", ($"/reviews/{Model.Slot?.SlotId}", "Reviews"))
         </div>
         <div class="lh-content" id="lh-scores">
-            <div class="eight wide column">
-                @await Html.PartialAsync("Partials/LeaderboardPartial", 
-                           ViewData.WithLang(language).WithTime(timeZone).CanDelete(Model.User?.IsModerator ?? false))
-            </div>
+            @await Html.PartialAsync("Partials/FramePartial", ($"/scores/{Model.Slot?.SlotId}", "Scores"))
         </div>
     </div>
 </div>
@@ -222,49 +186,4 @@
     }
 }
 
-<script>
-const sidebarElements = Array.from(document.querySelectorAll(".lh-sidebar"));
-const contentElements = Array.from(document.querySelectorAll(".lh-content"));
-let selectedId = window.location.hash;
-if (selectedId.startsWith("#"))
-    selectedId = selectedId.substring(1);
-let selectedElement = document.getElementById(selectedId);
-// id = lh-sidebar element
-function setVisible(e){
-    let eTarget = document.getElementById(e.target);
-    if (!e || !eTarget) return;
-
-    // make all active elements not active
-    for (let active of document.getElementsByClassName("active")) {
-        active.classList.remove("active");
-    }
-    // hide all content divs
-    for (let i = 0; i < contentElements.length; i++){
-        contentElements[i].style.display = "none";
-    }
-    // unhide content
-    eTarget.style.display = "";
-    
-    e.classList.add("active");
-}
-
-sidebarElements.forEach(el => {
-    if (el.classList.contains("active")){
-        setVisible(el);
-    }
-    el.addEventListener('click', event => {
-        if (!event.target.target) return;
-
-        setVisible(event.target)
-    })
-})
-// set the active content window based on url
-if (selectedElement != null) {
-    while (selectedElement != null && !selectedElement.classList.contains("lh-content")){
-        selectedElement = selectedElement.parentElement;
-    }
-    
-    let sidebarEle = document.querySelector("[target=" + selectedElement.id + "]")
-    setVisible(sidebarEle);
-}
-</script>
+@await Html.PartialAsync("Partials/SectionScriptPartial")

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
@@ -1,10 +1,7 @@
 #nullable enable
-using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
-using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
-using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Mvc;
@@ -14,13 +11,6 @@ namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages;
 
 public class SlotPage : BaseLayout
 {
-    public Dictionary<CommentEntity, RatedCommentEntity?> Comments = new();
-    public List<ReviewEntity> Reviews = new();
-    public List<PhotoEntity> Photos = new();
-    public List<ScoreEntity> Scores = new();
-
-    public bool CommentsEnabled;
-    public readonly bool ReviewsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelReviewsEnabled;
 
     public SlotEntity? Slot;
     public SlotPage(DatabaseContext database) : base(database)
@@ -56,71 +46,10 @@ public class SlotPage : BaseLayout
             }
         }
 
-        if ((slot.Hidden || slot.SubLevel && (this.User == null && this.User != slot.Creator)) && !(this.User?.IsModerator ?? false))
+        if ((slot.Hidden || slot.SubLevel && this.User == null && this.User != slot.Creator) && !(this.User?.IsModerator ?? false))
             return this.NotFound();
 
         this.Slot = slot;
-
-        List<int> blockedUsers = this.User == null
-            ? new List<int>()
-            : await (
-                from blockedProfile in this.Database.BlockedProfiles
-                where blockedProfile.UserId == this.User.UserId
-                select blockedProfile.BlockedUserId).ToListAsync();
-        
-        this.CommentsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelCommentsEnabled && this.Slot.CommentsEnabled;
-        if (this.CommentsEnabled)
-        {
-            this.Comments = await this.Database.Comments.Include(p => p.Poster)
-                .OrderByDescending(p => p.Timestamp)
-                .Where(c => c.TargetId == id && c.Type == CommentType.Level)
-                .Where(c => !blockedUsers.Contains(c.PosterUserId))
-                .Include(c => c.Poster)
-                .Where(c => c.Poster.PermissionLevel != PermissionLevel.Banned)
-                .Take(50)
-                .ToDictionaryAsync(c => c,  _ => (RatedCommentEntity?)null);
-        }
-        else
-        {
-            this.Comments = new Dictionary<CommentEntity, RatedCommentEntity?>();
-        }
-
-        if (this.ReviewsEnabled)
-        {
-            this.Reviews = await this.Database.Reviews.Include(r => r.Reviewer)
-                .OrderByDescending(r => r.ThumbsUp - r.ThumbsDown)
-                .ThenByDescending(r => r.Timestamp)
-                .Where(r => r.SlotId == id)
-                .Where(r => !blockedUsers.Contains(r.ReviewerId))
-                .Take(50)
-                .ToListAsync();
-        }
-        else
-        {
-            this.Reviews = new List<ReviewEntity>();
-        }
-
-        this.Photos = await this.Database.Photos.Include(p => p.Creator)
-            .Include(p => p.PhotoSubjects)
-            .ThenInclude(ps => ps.User)
-            .OrderByDescending(p => p.Timestamp)
-            .Where(r => r.SlotId == id)
-            .Take(10)
-            .ToListAsync();
-
-        this.Scores = await this.Database.Scores.OrderByDescending(s => s.Points)
-            .ThenBy(s => s.ScoreId)
-            .Where(s => s.SlotId == id)
-            .Take(10)
-            .ToListAsync();
-
-        if (this.User == null) return this.Page();
-
-        foreach (KeyValuePair<CommentEntity, RatedCommentEntity?> kvp in this.Comments)
-        {
-            RatedCommentEntity? reaction = await this.Database.RatedComments.FirstOrDefaultAsync(r => r.UserId == this.User.UserId && r.CommentId == kvp.Key.CommentId);
-            this.Comments[kvp.Key] = reaction;
-        }
 
         return this.Page();
     }

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -176,7 +176,7 @@
             <iframe src="~/comments/user/@Model.ProfileUser.UserId"
                     title="Comments"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts"
+                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>
@@ -184,7 +184,7 @@
             <iframe src="~/photos/user/@Model.ProfileUser.UserId"
                     title="Photos"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts"
+                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>
@@ -192,7 +192,7 @@
             <iframe src="~/slots/by/@Model.ProfileUser.UserId"
                     title="Photos"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts"
+                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -177,17 +177,17 @@
         <div class="lh-content" id="lh-levels" style="display: none">      
             @await Html.PartialAsync("Partials/FramePartial", ($"/slots/by/{Model.ProfileUser.UserId}", "Slots"))
         </div>
-        <div class="lh-content" id="lh-playlists">
+        <div class="lh-content" id="lh-playlists" style="display: none">
             <div class="ui purple segment">
                 <p>@Model.Translate(GeneralStrings.Soon)</p>
             </div>
         </div>
         @if (Model.User == Model.ProfileUser)
         {
-            <div class="lh-content" id="lh-hearted">
+            <div class="lh-content" id="lh-hearted" style="display: none">
                 @await Html.PartialAsync("Partials/FramePartial", ($"/slots/hearted/{Model.ProfileUser.UserId}", "Hearted Slots"))
             </div>
-            <div class="lh-content" id="lh-queued">
+            <div class="lh-content" id="lh-queued" style="display: none">
                 @await Html.PartialAsync("Partials/FramePartial", ($"/slots/queued/{Model.ProfileUser.UserId}", "Queued Slots"))
             </div>
         }

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -172,11 +172,10 @@
         string divLength = isMobile ? "sixteen" : "thirteen";
     }
     <div class="@divLength wide stretched column">
-        <div class="lh-content" id="lh-comments">
+        <div class="lh-content active" id="lh-comments">
             <iframe src="~/comments/user/@Model.ProfileUser.UserId"
                     title="Comments"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>
@@ -184,7 +183,6 @@
             <iframe src="~/photos/user/@Model.ProfileUser.UserId"
                     title="Photos"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>
@@ -192,7 +190,6 @@
             <iframe src="~/slots/by/@Model.ProfileUser.UserId"
                     title="Photos"
                     style="width: 100%; height: 100%; border: 0"
-                    sandbox="allow-top-navigation allow-scripts allow-same-origin"
                     onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
             </iframe>
         </div>

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -4,7 +4,6 @@
 @using LBPUnion.ProjectLighthouse.Localization.StringLists
 @using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
 @using LBPUnion.ProjectLighthouse.Types.Entities.Level
-@using LBPUnion.ProjectLighthouse.Types.Entities.Profile
 @using LBPUnion.ProjectLighthouse.Types.Moderation.Cases
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.UserPage
 
@@ -27,12 +26,13 @@
         @if (Model.User != null && Model.User.IsModerator)
         {
             <b>Reason:</b>
-            <span>"@Model.ProfileUser.BannedReason"</span> <br />
+            <span>"@Model.ProfileUser.BannedReason"</span>
+            <br/>
             <p>
                 <i>Only you and other moderators may view the ban reason.</i>
             </p>
         }
-        else 
+        else
         {
             <p>This user has been banned for violating the Terms of Service. Remember to follow the rules!</p>
         }
@@ -42,20 +42,20 @@
 <div class="@(isMobile ? "" : "ui grid")">
     <div class="eight wide column">
         @await Html.PartialAsync("Partials/UserCardPartial", Model.ProfileUser, new ViewDataDictionary(ViewData)
-        {
-            {
-                "ShowLink", false
-            },
-            {
-                "IsMobile", Model.Request.IsMobile()
-            },
-            {
-                "Language", Model.GetLanguage()
-            },
-            {
-                "TimeZone", Model.GetTimeZone()
-            },
-        })
+               {
+                   {
+                       "ShowLink", false
+                   },
+                   {
+                       "IsMobile", Model.Request.IsMobile()
+                   },
+                   {
+                       "Language", Model.GetLanguage()
+                   },
+                   {
+                       "TimeZone", Model.GetTimeZone()
+                   },
+               })
     </div>
     <div class="eight wide right aligned column">
         <br>
@@ -140,12 +140,8 @@
 
 <div class="ui grid">
     @{
-        string outerDiv = isMobile ?
-            "horizontal-scroll" :
-            "three wide column";
-        string innerDiv = isMobile ?
-            "ui top attached tabular menu horizontal-scroll" :
-            "ui vertical fluid tabular menu";
+        string outerDiv = isMobile ? "horizontal-scroll" : "three wide column";
+        string innerDiv = isMobile ? "ui top attached tabular menu horizontal-scroll" : "ui vertical fluid tabular menu";
     }
     <div class="@outerDiv">
         <div class="@innerDiv">
@@ -155,7 +151,6 @@
             <a class="item lh-sidebar" target="lh-photos">
                 @Model.Translate(BaseLayoutStrings.HeaderPhotos)
             </a>
-                
             <a class="item lh-sidebar" target="lh-levels">
                 @Model.Translate(BaseLayoutStrings.HeaderSlots)
             </a>
@@ -178,56 +173,28 @@
     }
     <div class="@divLength wide stretched column">
         <div class="lh-content" id="lh-comments">
-            @if (Model.ProfileUser.IsBanned)
-            {
-                <div class="ui yellow segment" id="comments">
-                    <p><i>Comments are disabled because the user is banned.</i></p>
-                </div>
-            }
-            else
-            {
-                @await Html.PartialAsync("Partials/CommentsPartial", new ViewDataDictionary(ViewData.WithLang(language).WithTime(timeZone))
-                    { {"PageOwner", Model.ProfileUser.UserId}, })
-            }
+            <iframe src="~/comments/user/@Model.ProfileUser.UserId"
+                    title="Comments"
+                    style="width: 100%; height: 100%; border: 0"
+                    sandbox="allow-top-navigation allow-scripts"
+                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
+            </iframe>
         </div>
         <div class="lh-content" id="lh-photos">
-            <div class="ui purple segment" id="photos">
-                @if (Model.Photos != null && Model.Photos.Count != 0)
-                {
-                    <div class="ui center aligned grid">
-                        @foreach (PhotoEntity photo in Model.Photos)
-                        {
-                            string width = isMobile ? "sixteen" : "eight";
-                            bool canDelete = Model.User != null && (Model.User.IsModerator || Model.User.UserId == photo.CreatorId);
-                            <div class="@width wide column">
-                                @await photo.ToHtml(Html, ViewData, language, timeZone, canDelete)
-                            </div>
-                        }
-                    </div>
-                    @if (isMobile)
-                    {
-                        <br/>
-                    }
-                }
-                else
-                {
-                    <p>This user hasn't uploaded any photos</p>
-                }
-            </div>
+            <iframe src="~/photos/user/@Model.ProfileUser.UserId"
+                    title="Photos"
+                    style="width: 100%; height: 100%; border: 0"
+                    sandbox="allow-top-navigation allow-scripts"
+                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
+            </iframe>
         </div>
         <div class="lh-content" id="lh-levels">
-            <div class="ui green segment" id="levels">
-                @if (Model.Slots?.Count == 0)
-                {
-                    <p>This user hasn't published any levels</p>
-                }
-                @foreach (SlotEntity slot in Model.Slots ?? new List<SlotEntity>())
-                {
-                    <div class="ui segment">
-                        @await slot.ToHtml(Html, ViewData, Model.User, $"~/user/{Model.ProfileUser.UserId}#levels", language, timeZone, isMobile, true)
-                    </div>
-                }
-            </div>
+            <iframe src="~/slots/by/@Model.ProfileUser.UserId"
+                    title="Photos"
+                    style="width: 100%; height: 100%; border: 0"
+                    sandbox="allow-top-navigation allow-scripts"
+                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
+            </iframe>
         </div>
         <div class="lh-content" id="lh-playlists">
             <div class="ui purple segment">
@@ -291,7 +258,7 @@
             </div>
             <div class="ui fitted hidden divider"></div>
         }
-        
+
         @if (Model.ProfileUser.CommentsEnabled)
         {
             <div>
@@ -302,7 +269,7 @@
             </div>
             <div class="ui fitted hidden divider"></div>
         }
-        
+
         <div>
             <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipePlanets">
                 <i class="trash alternate icon"></i>
@@ -310,7 +277,7 @@
             </a>
         </div>
         <div class="ui fitted hidden divider"></div>
-        
+
         @if (Model.User.IsAdmin)
         {
             @await Html.PartialAsync("Partials/AdminSetGrantedSlotsFormPartial", Model.ProfileUser)
@@ -344,6 +311,12 @@ function setVisible(e){
     }
     // unhide content
     eTarget.style.display = "";
+    let frame = eTarget.children[0] || undefined;
+    if (frame !== undefined && frame.nodeName === "IFRAME"){
+        console.log(eTarget.id + " - frame not null - " + frame.contentWindow.document.body.scrollHeight);
+        frame.style.height = frame.contentWindow.document.body.scrollHeight + "px"; 
+    }
+    console.dir(eTarget);
     
     e.classList.add("active");
 }

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -2,8 +2,6 @@
 @using System.Web
 @using LBPUnion.ProjectLighthouse.Extensions
 @using LBPUnion.ProjectLighthouse.Localization.StringLists
-@using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
-@using LBPUnion.ProjectLighthouse.Types.Entities.Level
 @using LBPUnion.ProjectLighthouse.Types.Moderation.Cases
 @model LBPUnion.ProjectLighthouse.Servers.Website.Pages.UserPage
 
@@ -15,8 +13,6 @@
     Model.Description = Model.ProfileUser!.Biography;
 
     bool isMobile = Request.IsMobile();
-    string language = Model.GetLanguage();
-    string timeZone = Model.GetTimeZone();
 }
 
 @if (Model.ProfileUser.IsBanned)
@@ -172,26 +168,14 @@
         string divLength = isMobile ? "sixteen" : "thirteen";
     }
     <div class="@divLength wide stretched column">
-        <div class="lh-content active" id="lh-comments">
-            <iframe src="~/comments/user/@Model.ProfileUser.UserId"
-                    title="Comments"
-                    style="width: 100%; height: 100%; border: 0"
-                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
-            </iframe>
+        <div class="lh-content" id="lh-comments">
+            @await Html.PartialAsync("Partials/FramePartial", ($"/comments/user/{Model.ProfileUser.UserId}", "Comments"))
         </div>
-        <div class="lh-content" id="lh-photos">
-            <iframe src="~/photos/user/@Model.ProfileUser.UserId"
-                    title="Photos"
-                    style="width: 100%; height: 100%; border: 0"
-                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
-            </iframe>
+        <div class="lh-content" id="lh-photos" style="display: none">
+            @await Html.PartialAsync("Partials/FramePartial", ($"/photos/user/{Model.ProfileUser.UserId}", "Photos"))
         </div>
-        <div class="lh-content" id="lh-levels">
-            <iframe src="~/slots/by/@Model.ProfileUser.UserId"
-                    title="Photos"
-                    style="width: 100%; height: 100%; border: 0"
-                    onload="this.style.height=(this.contentWindow.document.body.scrollHeight)+'px';">
-            </iframe>
+        <div class="lh-content" id="lh-levels" style="display: none">      
+            @await Html.PartialAsync("Partials/FramePartial", ($"/slots/by/{Model.ProfileUser.UserId}", "Slots"))
         </div>
         <div class="lh-content" id="lh-playlists">
             <div class="ui purple segment">
@@ -201,40 +185,10 @@
         @if (Model.User == Model.ProfileUser)
         {
             <div class="lh-content" id="lh-hearted">
-                <div class="ui pink segment" id="hearted">
-                    @if (Model.HeartedSlots?.Count == 0)
-                    {
-                        <p>You haven't hearted any levels</p>
-                    }
-                    else
-                    {
-                        <p>You have hearted @(Model.HeartedSlots?.Count) levels</p>
-                    }
-                    @foreach (SlotEntity slot in Model.HeartedSlots ?? new List<SlotEntity>())
-                    {
-                        <div class="ui segment">
-                            @await slot.ToHtml(Html, ViewData, Model.User, $"~/user/{Model.ProfileUser.UserId}#hearted", language, timeZone, isMobile, true)
-                        </div>
-                    }
-                </div>
+                @await Html.PartialAsync("Partials/FramePartial", ($"/slots/hearted/{Model.ProfileUser.UserId}", "Hearted Slots"))
             </div>
             <div class="lh-content" id="lh-queued">
-                <div class="ui yellow segment" id="queued">
-                    @if (Model.QueuedSlots?.Count == 0)
-                    {
-                        <p>You haven't queued any levels</p>
-                    }
-                    else
-                    {
-                        <p>There are @(Model.QueuedSlots?.Count) levels in your queue</p>
-                    }
-                    @foreach (SlotEntity slot in Model.QueuedSlots ?? new List<SlotEntity>())
-                    {
-                        <div class="ui segment">
-                            @await slot.ToHtml(Html, ViewData, Model.User, $"~/user/{Model.ProfileUser.UserId}#queued", language, timeZone, isMobile, true)
-                        </div>
-                    }
-                </div>
+                @await Html.PartialAsync("Partials/FramePartial", ($"/slots/queued/{Model.ProfileUser.UserId}", "Queued Slots"))
             </div>
         }
     </div>
@@ -286,55 +240,4 @@
     }
 }
 
-<script>
-const sidebarElements = Array.from(document.querySelectorAll(".lh-sidebar"));
-const contentElements = Array.from(document.querySelectorAll(".lh-content"));
-let selectedId = window.location.hash;
-if (selectedId.startsWith("#"))
-    selectedId = selectedId.substring(1);
-let selectedElement = document.getElementById(selectedId);
-// id = lh-sidebar element
-function setVisible(e){
-    let eTarget = document.getElementById(e.target);
-    if (!e || !eTarget) return;
-
-    // make all active elements not active
-    for (let active of document.getElementsByClassName("active")) {
-        active.classList.remove("active");
-    }
-    // hide all content divs
-    for (let i = 0; i < contentElements.length; i++){
-        contentElements[i].style.display = "none";
-    }
-    // unhide content
-    eTarget.style.display = "";
-    let frame = eTarget.children[0] || undefined;
-    if (frame !== undefined && frame.nodeName === "IFRAME"){
-        console.log(eTarget.id + " - frame not null - " + frame.contentWindow.document.body.scrollHeight);
-        frame.style.height = frame.contentWindow.document.body.scrollHeight + "px"; 
-    }
-    console.dir(eTarget);
-    
-    e.classList.add("active");
-}
-
-sidebarElements.forEach(el => {
-    if (el.classList.contains("active")){
-        setVisible(el);
-    }
-    el.addEventListener('click', event => {
-        if (!event.target.target) return;
-
-        setVisible(event.target)
-    })
-})
-// set the active content window based on url
-if (selectedElement != null) {
-    while (selectedElement != null && !selectedElement.classList.contains("lh-content")){
-        selectedElement = selectedElement.parentElement;
-    }
-    
-    let sidebarEle = document.querySelector("[target=" + selectedElement.id + "]")
-    setVisible(sidebarEle);
-}
-</script>
+@await Html.PartialAsync("Partials/SectionScriptPartial")

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
@@ -1,8 +1,6 @@
 #nullable enable
-using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
-using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Levels;
@@ -14,19 +12,9 @@ namespace LBPUnion.ProjectLighthouse.Servers.Website.Pages;
 
 public class UserPage : BaseLayout
 {
-    public Dictionary<CommentEntity, RatedCommentEntity?> Comments = new();
-
-    public bool CommentsEnabled;
-
     public bool IsProfileUserHearted;
 
     public bool IsProfileUserBlocked;
-
-    public List<PhotoEntity>? Photos;
-    public List<SlotEntity>? Slots;
-
-    public List<SlotEntity>? HeartedSlots;
-    public List<SlotEntity>? QueuedSlots;
 
     public UserEntity? ProfileUser;
     public UserPage(DatabaseContext database) : base(database)
@@ -59,68 +47,7 @@ public class UserPage : BaseLayout
             }
         }
 
-        this.Photos = await this.Database.Photos.Include(p => p.Slot)
-            .Include(p => p.PhotoSubjects)
-            .ThenInclude(ps => ps.User)
-            .OrderByDescending(p => p.Timestamp)
-            .Where(p => p.CreatorId == userId)
-            .Take(6)
-            .ToListAsync();
-
-        this.Slots = await this.Database.Slots.Include(p => p.Creator)
-            .OrderByDescending(s => s.LastUpdated)
-            .Where(p => p.CreatorId == userId)
-            .Take(10)
-            .ToListAsync();
-
-        if (this.User == this.ProfileUser)
-        {
-            this.QueuedSlots = await this.Database.QueuedLevels.Include(h => h.Slot)
-                .Where(q => this.User != null && q.UserId == this.User.UserId)
-                .OrderByDescending(q => q.QueuedLevelId)
-                .Select(q => q.Slot)
-                .Where(s => s.Type == SlotType.User)
-                .Take(10)
-                .ToListAsync();
-            this.HeartedSlots = await this.Database.HeartedLevels.Include(h => h.Slot)
-                .Where(h => this.User != null && h.UserId == this.User.UserId)
-                .OrderByDescending(h => h.HeartedLevelId)
-                .Select(h => h.Slot)
-                .Where(s => s.Type == SlotType.User)
-                .Take(10)
-                .ToListAsync();
-        }
-
-        this.CommentsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelCommentsEnabled && this.ProfileUser.CommentsEnabled;
-
-        if (this.CommentsEnabled)
-        {
-            List<int> blockedUsers = this.User == null ? new List<int>() : await 
-            (from blockedProfile in this.Database.BlockedProfiles
-                where blockedProfile.UserId == this.User.UserId
-                select blockedProfile.BlockedUserId).ToListAsync();
-            
-            this.Comments = await this.Database.Comments.Include(p => p.Poster)
-                .OrderByDescending(p => p.Timestamp)
-                .Where(p => p.TargetId == userId && p.Type == CommentType.Profile)
-                .Where(p => !blockedUsers.Contains(p.PosterUserId))
-                .Take(50)
-                .ToDictionaryAsync(c => c, _ => (RatedCommentEntity?) null);
-        }
-        else
-        {
-            this.Comments = new Dictionary<CommentEntity, RatedCommentEntity?>();
-        }
-
         if (this.User == null) return this.Page();
-
-        foreach (KeyValuePair<CommentEntity, RatedCommentEntity?> kvp in this.Comments)
-        {
-            RatedCommentEntity? reaction = await this.Database.RatedComments.Where(r => r.CommentId == kvp.Key.CommentId)
-                .Where(r => r.UserId == this.User.UserId)
-                .FirstOrDefaultAsync();
-            this.Comments[kvp.Key] = reaction;
-        }
 
         this.IsProfileUserHearted = await this.Database.HeartedProfiles
             .Where(h => h.HeartedUserId == this.ProfileUser.UserId)

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
@@ -1,9 +1,7 @@
 #nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
-using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
-using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
+++ b/ProjectLighthouse.Servers.Website/Startup/WebsiteStartup.cs
@@ -38,6 +38,16 @@ public class WebsiteStartup
     {
         services.AddControllers();
         #if DEBUG
+        // Add CORS for debugging
+        services.AddCors(options =>
+        {
+            options.AddDefaultPolicy(policy =>
+            {
+                policy.AllowAnyHeader();
+                policy.AllowAnyMethod();
+                policy.AllowAnyOrigin();
+            });
+        });
         services.AddRazorPages().WithRazorPagesAtContentRoot().AddRazorRuntimeCompilation((options) =>
         {
             // jank but works
@@ -112,6 +122,7 @@ public class WebsiteStartup
     {
         #if DEBUG
         app.UseDeveloperExceptionPage();
+        app.UseCors();
         #endif
 
         app.UseStatusCodePagesWithReExecute("/404");

--- a/ProjectLighthouse/Types/Entities/Level/ReviewEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Level/ReviewEntity.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -15,12 +14,12 @@ public class ReviewEntity
     public int ReviewerId { get; set; }
 
     [ForeignKey(nameof(ReviewerId))]
-    public UserEntity? Reviewer { get; set; }
+    public UserEntity Reviewer { get; set; }
 
     public int SlotId { get; set; }
 
     [ForeignKey(nameof(SlotId))]
-    public SlotEntity? Slot { get; set; }
+    public SlotEntity Slot { get; set; }
 
     public long Timestamp { get; set; }
 

--- a/ProjectLighthouse/Types/Entities/Profile/CommentEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Profile/CommentEntity.cs
@@ -50,9 +50,11 @@ public class CommentEntity
             return "This comment has been deleted by the author.";
         }
 
-        UserEntity deletedBy = database.Users.FirstOrDefault(u => u.Username == this.DeletedBy);
+        int deletedById = database.Users.Where(u => u.Username == this.DeletedBy)
+            .Select(u => u.UserId)
+            .FirstOrDefault();
 
-        if (deletedBy != null && deletedBy.UserId == this.TargetId)
+        if (deletedById != 0 && deletedById == this.TargetId)
         {
             return "This comment has been deleted by the player.";
         }


### PR DESCRIPTION
This PR turns the major sections of profiles and levels on the website into their own pages that are loaded through iFrames to allow the website to mimic responsiveness. This way you can go through pages of comments without reloading the entire page. It also has the benefit of consolidating all the styling and logic for loading comments, photos, and scores into a single page. 

## Current drawbacks
When you click a link in an iframe it doesn't immediately load the page like you would expect because instead, the iframe travels to that link. My solution for this was to put a script in BaseLayout that would detect if the window is in an iframe, if it is then it sets the top-level window location to the current page location. It works fairly seamlessly but it does introduce some delay that some users might notice. There might be a better solution to this and I still have yet to try more solutions.

## Todos
- [ ] Fix off by one error in pagination
- [ ] Implement viewing different score types
- [ ] Make pagination buttons look pretty
- [ ] Snap parent page to the top of the frame whenever new page loads?

<details>
<summary>Pictures</summary>

![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/676d225b-f9b9-4661-aefd-35dc2246f519)

![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/00a97d75-5b10-4004-b157-92acdb13c86e)

![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/c8895461-16e5-4b35-8063-0d66ded1bc76)
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/c431b145-2948-4166-9068-c8a43c4a79ea)
![image](https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/a896cfe1-2c2b-43d1-967e-5e3ffd5f6fac)

</details>

</summary>