### PR TITLE
Add workaround for the clickable user links in a grief report

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ReportPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ReportPartial.cshtml
@@ -25,7 +25,7 @@
         @foreach (ReportPlayer player in Model.XmlPlayers)
         {
             <div id="hover-subjects-@Model.ReportId" class="hover-players">
-                <a href="/">@player.Name</a>
+                <a href="/users/0?name=@player.Name">@player.Name</a>
             </div>
         }
 


### PR DESCRIPTION
Pretty self explanatory - since the grief report only contains the username of the user instead of the ID, I made the clickable links redirect to the search page for that username.