### PR TITLE
Simplify rank badges and implement profile tags

### DIFF
--- a/ProjectLighthouse.Localization/Profile.resx
+++ b/ProjectLighthouse.Localization/Profile.resx
@@ -27,4 +27,7 @@
     <data name="title" xml:space="preserve">
         <value>{0}'s user page</value>
     </data>
+    <data name="profile_tag" xml:space="preserve">
+        <value>Profile Tag</value>
+    </data>
 </root>

--- a/ProjectLighthouse.Localization/StringLists/ProfileStrings.cs
+++ b/ProjectLighthouse.Localization/StringLists/ProfileStrings.cs
@@ -5,6 +5,7 @@ public static class ProfileStrings
     public static readonly TranslatableString Title = create("title");
     public static readonly TranslatableString Biography = create("biography");
     public static readonly TranslatableString NoBiography = create("no_biography");
+    public static readonly TranslatableString ProfileTag = create("profile_tag");
 
     private static TranslatableString create(string key) => new(TranslationAreas.Profile, key);
 }

--- a/ProjectLighthouse.Servers.Website/Extensions/FormattingExtensions.cs
+++ b/ProjectLighthouse.Servers.Website/Extensions/FormattingExtensions.cs
@@ -28,7 +28,7 @@ public static class FormattingExtensions
         return permissionLevel switch
         {
             PermissionLevel.Administrator => "red",
-            PermissionLevel.Moderator => "rgb(200, 130, 0)",
+            PermissionLevel.Moderator => "orange",
             _ => "",
         };
     }

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
@@ -25,8 +25,14 @@
                 <a href="~/user/@Model.UserId">@Model.Username</a>
                     @if (Model.IsModerator)
                     {
-                        <span class="permission-badge ui label @Model.PermissionLevel.ToHtmlColor()">
+                        <span class="profile-tag ui label @Model.PermissionLevel.ToHtmlColor()">
                             @Model.PermissionLevel.ToString()
+                        </span>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(Model.ProfileVanityTag))
+                    {
+                        <span class="profile-tag ui label">
+                            @Model.ProfileVanityTag
                         </span>
                     }
             </h2>
@@ -37,8 +43,14 @@
                 @Model.Username
                 @if (Model.IsModerator)
                 {
-                    <span class="permission-badge ui label @Model.PermissionLevel.ToHtmlColor()">
+                    <span class="profile-tag ui label @Model.PermissionLevel.ToHtmlColor()">
                         @Model.PermissionLevel.ToString()
+                    </span>
+                }
+                @if (!string.IsNullOrWhiteSpace(Model.ProfileVanityTag))
+                {
+                    <span class="profile-tag ui label">
+                        @Model.ProfileVanityTag
                     </span>
                 }
             </h1>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
@@ -25,7 +25,7 @@
                 <a href="~/user/@Model.UserId">@Model.Username</a>
                     @if (Model.IsModerator)
                     {
-                        <span class="permissionBadge" style="background-color: @Model.PermissionLevel.ToHtmlColor();">
+                        <span class="permission-badge ui label @Model.PermissionLevel.ToHtmlColor()">
                             @Model.PermissionLevel.ToString()
                         </span>
                     }
@@ -37,7 +37,7 @@
                 @Model.Username
                 @if (Model.IsModerator)
                 {
-                    <span class="permissionBadge" style="background-color: @Model.PermissionLevel.ToHtmlColor();">
+                    <span class="permission-badge" style="background-color: @Model.PermissionLevel.ToHtmlColor();">
                         @Model.PermissionLevel.ToString()
                     </span>
                 }

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
@@ -29,10 +29,10 @@
                             @Model.PermissionLevel.ToString()
                         </span>
                     }
-                    @if (!string.IsNullOrWhiteSpace(Model.ProfileVanityTag))
+                    @if (!string.IsNullOrWhiteSpace(Model.ProfileTag))
                     {
                         <span class="profile-tag ui label">
-                            @Model.ProfileVanityTag
+                            @Model.ProfileTag
                         </span>
                     }
             </h2>
@@ -47,10 +47,10 @@
                         @Model.PermissionLevel.ToString()
                     </span>
                 }
-                @if (!string.IsNullOrWhiteSpace(Model.ProfileVanityTag))
+                @if (!string.IsNullOrWhiteSpace(Model.ProfileTag))
                 {
                     <span class="profile-tag ui label">
-                        @Model.ProfileVanityTag
+                        @Model.ProfileTag
                     </span>
                 }
             </h1>

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
@@ -37,7 +37,7 @@
                 @Model.Username
                 @if (Model.IsModerator)
                 {
-                    <span class="permission-badge" style="background-color: @Model.PermissionLevel.ToHtmlColor();">
+                    <span class="permission-badge ui label @Model.PermissionLevel.ToHtmlColor()">
                         @Model.PermissionLevel.ToString()
                     </span>
                 }

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -72,7 +72,7 @@ function onSubmit(e){
                     </div>
                 }
                 <div class="field">
-                    <label style="text-align: left" for="vanityTag">@Model.Translate(ProfileStrings.ProfileTag)</label>
+                    <label style="text-align: left" for="vanityTag">@Model.Translate(ProfileStrings.ProfileTag) @if (!Model.User!.IsAdmin) { <i class="ui icon lock"></i> }</label>
                     <input type="text" name="vanityTag" id="vanityTag" value="@Model.ProfileUser.ProfileVanityTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>    
                 </div>
                 <div class="field">

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -79,7 +79,7 @@ function onSubmit(e){
                             <i class="ui icon lock"></i>
                         }
                     </label>
-                    <input type="text" name="profileTag" id="profileTag" value="@Model.ProfileUser.ProfileTag" placeholder="Profile Tag"@(!Model.User!.IsAdmin ? "readonly" : "")>
+                    <input type="text" name="profileTag" id="profileTag" value="@Model.ProfileUser.ProfileTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>
                 </div>
                 <div class="field">
                     <label style="text-align: left" for="biography">@Model.Translate(ProfileStrings.Biography)</label>

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -73,7 +73,7 @@ function onSubmit(e){
                 }
                 <div class="field">
                     <label style="text-align: left" for="vanityTag">@Model.Translate(ProfileStrings.ProfileTag)</label>
-                    <input type="text" name="vanityTag" id="vanityTag" value="@Model.ProfileUser.ProfileVanityTag" placeholder="Profile Tag">    
+                    <input type="text" name="vanityTag" id="vanityTag" value="@Model.ProfileUser.ProfileVanityTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>    
                 </div>
                 <div class="field">
                     <label style="text-align: left" for="biography">@Model.Translate(ProfileStrings.Biography)</label>

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -72,6 +72,10 @@ function onSubmit(e){
                     </div>
                 }
                 <div class="field">
+                    <label style="text-align: left" for="vanityTag">@Model.Translate(ProfileStrings.ProfileTag)</label>
+                    <input type="text" name="vanityTag" id="vanityTag" value="@Model.ProfileUser.ProfileVanityTag" placeholder="Profile Tag">    
+                </div>
+                <div class="field">
                     <label style="text-align: left" for="biography">@Model.Translate(ProfileStrings.Biography)</label>
                     <textarea name="biography" id="biography" spellcheck="false" placeholder="Biography">@HttpUtility.HtmlDecode(Model.ProfileUser.Biography)</textarea>
                 </div>

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -72,8 +72,14 @@ function onSubmit(e){
                     </div>
                 }
                 <div class="field">
-                    <label style="text-align: left" for="profileTag">@Model.Translate(ProfileStrings.ProfileTag) @if (!Model.User!.IsAdmin) { <i class="ui icon lock"></i> }</label>
-                    <input type="text" name="profileTag" id="profileTag" value="@Model.ProfileUser.ProfileTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>    
+                    <label style="text-align: left" for="profileTag">
+                        @Model.Translate(ProfileStrings.ProfileTag)
+                        @if (!Model.User!.IsAdmin)
+                        {
+                            <i class="ui icon lock"></i>
+                        }
+                    </label>
+                    <input type="text" name="profileTag" id="profileTag" value="@Model.ProfileUser.ProfileTag" placeholder="Profile Tag"@(!Model.User!.IsAdmin ? "readonly" : "")>
                 </div>
                 <div class="field">
                     <label style="text-align: left" for="biography">@Model.Translate(ProfileStrings.Biography)</label>

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -61,7 +61,7 @@ function onSubmit(e){
                     </div>
                 </div>
                 <div class="field">
-                    <label style="text-align: left" for="username">@Model.Translate(GeneralStrings.Username)</label>
+                    <label style="text-align: left" for="username">@Model.Translate(GeneralStrings.Username) <i class="ui icon lock"></i></label>
                     <input type="text" name="username" id="username" value="@Model.ProfileUser.Username" placeholder="Username" readonly>
                 </div>
                 @if (ServerConfiguration.Instance.Mail.MailEnabled && (Model.User == Model.ProfileUser || Model.User!.IsAdmin))

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml
@@ -72,8 +72,8 @@ function onSubmit(e){
                     </div>
                 }
                 <div class="field">
-                    <label style="text-align: left" for="vanityTag">@Model.Translate(ProfileStrings.ProfileTag) @if (!Model.User!.IsAdmin) { <i class="ui icon lock"></i> }</label>
-                    <input type="text" name="vanityTag" id="vanityTag" value="@Model.ProfileUser.ProfileVanityTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>    
+                    <label style="text-align: left" for="profileTag">@Model.Translate(ProfileStrings.ProfileTag) @if (!Model.User!.IsAdmin) { <i class="ui icon lock"></i> }</label>
+                    <input type="text" name="profileTag" id="profileTag" value="@Model.ProfileUser.ProfileTag" placeholder="Profile Tag" @(!Model.User!.IsAdmin ? "readonly" : "")>    
                 </div>
                 <div class="field">
                     <label style="text-align: left" for="biography">@Model.Translate(ProfileStrings.Biography)</label>

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -20,7 +20,17 @@ public class UserSettingsPage : BaseLayout
     {}
 
     [SuppressMessage("ReSharper", "SpecifyStringComparison")]
-    public async Task<IActionResult> OnPost([FromRoute] int userId, [FromForm] string? avatar, [FromForm] string? username, [FromForm] string? email, [FromForm] string profileTag, [FromForm] string? biography, [FromForm] string? timeZone, [FromForm] string? language)
+    public async Task<IActionResult> OnPost
+    (
+        [FromRoute] int userId,
+        [FromForm] string? avatar,
+        [FromForm] string? username,
+        [FromForm] string? email,
+        [FromForm] string profileTag,
+        [FromForm] string? biography,
+        [FromForm] string? timeZone,
+        [FromForm] string? language
+    )
     {
         this.ProfileUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == userId);
         if (this.ProfileUser == null) return this.NotFound();

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -20,7 +20,7 @@ public class UserSettingsPage : BaseLayout
     {}
 
     [SuppressMessage("ReSharper", "SpecifyStringComparison")]
-    public async Task<IActionResult> OnPost([FromRoute] int userId, [FromForm] string? avatar, [FromForm] string? username, [FromForm] string? email, [FromForm] string vanityTag, [FromForm] string? biography, [FromForm] string? timeZone, [FromForm] string? language)
+    public async Task<IActionResult> OnPost([FromRoute] int userId, [FromForm] string? avatar, [FromForm] string? username, [FromForm] string? email, [FromForm] string profileTag, [FromForm] string? biography, [FromForm] string? timeZone, [FromForm] string? language)
     {
         this.ProfileUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == userId);
         if (this.ProfileUser == null) return this.NotFound();
@@ -33,7 +33,7 @@ public class UserSettingsPage : BaseLayout
 
         if (avatarHash != null) this.ProfileUser.IconHash = avatarHash;
 
-        if (this.User.IsAdmin) this.ProfileUser.ProfileVanityTag = vanityTag;
+        if (this.User.IsAdmin) this.ProfileUser.ProfileTag = profileTag;
 
         if (biography != null)
         {

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -20,7 +20,7 @@ public class UserSettingsPage : BaseLayout
     {}
 
     [SuppressMessage("ReSharper", "SpecifyStringComparison")]
-    public async Task<IActionResult> OnPost([FromRoute] int userId, [FromForm] string? avatar, [FromForm] string? username, [FromForm] string? email, [FromForm] string? biography, [FromForm] string? timeZone, [FromForm] string? language)
+    public async Task<IActionResult> OnPost([FromRoute] int userId, [FromForm] string? avatar, [FromForm] string? username, [FromForm] string? email, [FromForm] string vanityTag, [FromForm] string? biography, [FromForm] string? timeZone, [FromForm] string? language)
     {
         this.ProfileUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == userId);
         if (this.ProfileUser == null) return this.NotFound();
@@ -32,6 +32,8 @@ public class UserSettingsPage : BaseLayout
         string? avatarHash = await FileHelper.ParseBase64Image(avatar);
 
         if (avatarHash != null) this.ProfileUser.IconHash = avatarHash;
+
+        if (this.User.IsAdmin) this.ProfileUser.ProfileVanityTag = vanityTag;
 
         if (biography != null)
         {

--- a/ProjectLighthouse/Migrations/20230827004014_AddProfileVanityTagsToUsers.cs
+++ b/ProjectLighthouse/Migrations/20230827004014_AddProfileVanityTagsToUsers.cs
@@ -1,0 +1,30 @@
+﻿using LBPUnion.ProjectLighthouse.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectLighthouse.Migrations
+{
+    [DbContext(typeof(DatabaseContext))]
+    [Migration("20230827004014_AddProfileVanityTagsToUsers")]
+    public partial class AddProfileVanityTagsToUsers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProfileVanityTag",
+                table: "Users",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProfileVanityTag",
+                table: "Users");
+        }
+    }
+}

--- a/ProjectLighthouse/Migrations/20230827004014_AddProfileVanityTagsToUsers.cs
+++ b/ProjectLighthouse/Migrations/20230827004014_AddProfileVanityTagsToUsers.cs
@@ -13,7 +13,7 @@ namespace ProjectLighthouse.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
-                name: "ProfileVanityTag",
+                name: "ProfileTag",
                 table: "Users",
                 type: "longtext",
                 nullable: true)
@@ -23,7 +23,7 @@ namespace ProjectLighthouse.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
-                name: "ProfileVanityTag",
+                name: "ProfileTag",
                 table: "Users");
         }
     }

--- a/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -16,7 +16,7 @@ namespace ProjectLighthouse.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "7.0.8")
+                .HasAnnotation("ProductVersion", "7.0.10")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("LBPUnion.ProjectLighthouse.Types.Entities.Interaction.HeartedLevelEntity", b =>
@@ -856,6 +856,9 @@ namespace ProjectLighthouse.Migrations
                         .HasColumnType("longtext");
 
                     b.Property<string>("PlanetHashLBPVita")
+                        .HasColumnType("longtext");
+
+                    b.Property<string>("ProfileVanityTag")
                         .HasColumnType("longtext");
 
                     b.Property<int>("ProfileVisibility")

--- a/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
+++ b/ProjectLighthouse/ProjectLighthouse/Migrations/DatabaseModelSnapshot.cs
@@ -858,7 +858,7 @@ namespace ProjectLighthouse.Migrations
                     b.Property<string>("PlanetHashLBPVita")
                         .HasColumnType("longtext");
 
-                    b.Property<string>("ProfileVanityTag")
+                    b.Property<string>("ProfileTag")
                         .HasColumnType("longtext");
 
                     b.Property<int>("ProfileVisibility")

--- a/ProjectLighthouse/StaticFiles/css/styles.css
+++ b/ProjectLighthouse/StaticFiles/css/styles.css
@@ -244,7 +244,7 @@ div.cardStatsUnderTitle > span {
 
 /*#region User permission badge */
 
-.permission-badge {
+.profile-tag {
     position: relative;
     bottom: 0.45rem;
 }

--- a/ProjectLighthouse/StaticFiles/css/styles.css
+++ b/ProjectLighthouse/StaticFiles/css/styles.css
@@ -244,19 +244,9 @@ div.cardStatsUnderTitle > span {
 
 /*#region User permission badge */
 
-.permissionBadge {
-    width: auto;
-    height: auto;
-    color: white;
-    background-color: inherit;
-    border: 0px solid black;
-    border-radius: 50px;
-    font-weight: 200;
-    font-size: 10pt;
-    padding: 1px;
-    padding-left: 6px;
-    padding-right: 6px;
-    vertical-align: top;
+.permission-badge {
+    position: relative;
+    bottom: 0.45rem;
 }
 
 /*#endregion User permission badge */

--- a/ProjectLighthouse/Types/Entities/Profile/UserEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Profile/UserEntity.cs
@@ -132,7 +132,7 @@ public class UserEntity
     // should not be adjustable by user
     public bool CommentsEnabled { get; set; } = true;
     
-    public string ProfileVanityTag { get; set; } = "";
+    public string ProfileTag { get; set; } = "";
 
     #nullable enable
     public override bool Equals(object? obj)

--- a/ProjectLighthouse/Types/Entities/Profile/UserEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Profile/UserEntity.cs
@@ -72,6 +72,7 @@ public class UserEntity
 
     public string PlanetHashLBP2 { get; set; } = "";
 
+    // ReSharper disable once InconsistentNaming
     public string PlanetHashLBP2CC { get; set; } = "";
 
     public string PlanetHashLBP3 { get; set; } = "";
@@ -130,6 +131,8 @@ public class UserEntity
 
     // should not be adjustable by user
     public bool CommentsEnabled { get; set; } = true;
+    
+    public string ProfileVanityTag { get; set; } = "";
 
     #nullable enable
     public override bool Equals(object? obj)


### PR DESCRIPTION
This PR simplifies the website rank badges to use existing classes, and also implements a small feature that allows server administrators to grant vanity profile tags to users, i.e. for winning an event.

<img width="455" alt="Screenshot 2023-08-26 at 9 35 14 PM" src="https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/c00292ca-0d02-4c3d-879a-5c57452287a3">