### PR TITLE
Add links to license and source code in footer

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -199,7 +199,7 @@
                     <p>@Model.Translate(BaseLayoutStrings.GeneratedModified)</p>
                 }
                 <span style="float: right;">
-                    <a href="https://github.com/LBPUnion/ProjectLighthouse/blob/main/LICENSE">
+                    <a href="https://github.com/LBPUnion/ProjectLighthouse/blob/main/LICENSE" target="_blank">
                         AGPL-3.0 License
                     </a>
                     &centerdot;

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -191,12 +191,22 @@
     <footer>
         <div class="ui black attached inverted segment">
             <div class="ui container">
-
-                <p>@Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)</p>
+                <span>
+                    @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)
+                </span>
                 @if (VersionHelper.IsDirty)
                 {
                     <p>@Model.Translate(BaseLayoutStrings.GeneratedModified)</p>
                 }
+                <span style="float: right;">
+                    <a href="https://github.com/LBPUnion/ProjectLighthouse/blob/main/LICENSE">
+                        AGPL-3.0 License
+                    </a>
+                    &centerdot;
+                    <a href="@VersionHelper.Remotes[0]" target="_blank">
+                        Source Code
+                    </a>
+                </span>
             </div>
         </div>
         @if (ServerStatics.IsDebug())

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -192,15 +192,11 @@
         <div class="ui black attached inverted segment">
             <div class="ui container">
                 @{
-                    string? remoteUrl = VersionHelper.DetermineRemoteUrl(false);
+                    string? remoteUrl = VersionHelper.DetermineRemoteUrl();
                 }
                 <span>
                     @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)
                 </span>
-                @if (VersionHelper.IsDirty)
-                {
-                    <p>@Model.Translate(BaseLayoutStrings.GeneratedModified)</p>
-                }
                 <span style="float: right;">
                     <a href="https://github.com/LBPUnion/ProjectLighthouse/blob/main/LICENSE" target="_blank">
                         AGPL-3.0 License
@@ -217,6 +213,10 @@
                         <span class="ui text red">Cannot Detect Source Code</span>
                     }
                 </span>
+                @if (VersionHelper.IsDirty)
+                {
+                    <p>@Model.Translate(BaseLayoutStrings.GeneratedModified)</p>
+                }
             </div>
         </div>
         @if (ServerStatics.IsDebug())

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -203,7 +203,7 @@
                         AGPL-3.0 License
                     </a>
                     &centerdot;
-                    <a href="@VersionHelper.Remotes[0]" target="_blank">
+                    <a href="@VersionHelper.Remotes[0].Replace(" (fetch)", "")" target="_blank">
                         Source Code
                     </a>
                 </span>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -191,6 +191,9 @@
     <footer>
         <div class="ui black attached inverted segment">
             <div class="ui container">
+                @{
+                    string? firstRemoteUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("git@", "https://").Replace(":", "").Replace(".git", "");
+                }
                 <span>
                     @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)
                 </span>
@@ -203,9 +206,16 @@
                         AGPL-3.0 License
                     </a>
                     &centerdot;
-                    <a href="@VersionHelper.Remotes[0].Split(".git")[0]" target="_blank">
-                        Source Code
-                    </a>
+                    @if (!string.IsNullOrWhiteSpace(firstRemoteUrl))
+                    {
+                        <a href="@firstRemoteUrl" target="_blank">
+                            Source Code
+                        </a>    
+                    }
+                    else
+                    {
+                        <span class="ui text red">Cannot Determine Remote</span>
+                    }
                 </span>
             </div>
         </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -192,7 +192,7 @@
         <div class="ui black attached inverted segment">
             <div class="ui container">
                 @{
-                    string? remoteUrl = VersionHelper.DetermineRemoteUrl();
+                    string? remoteUrl = VersionHelper.DetermineRemoteUrl(false);
                 }
                 <span>
                     @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -197,11 +197,11 @@
 
                     if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("git@"))
                     {
-                        firstRemoteParsedUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("git@", "").Replace(":", "").Split(".git").FirstOrDefault();    
+                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "").Split(".git").FirstOrDefault();    
                     }
                     else if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("https://"))
                     {
-                        firstRemoteParsedUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("https://", "").Split(".git").FirstOrDefault();
+                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
                     }
                     else
                     {

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -203,7 +203,7 @@
                         AGPL-3.0 License
                     </a>
                     &centerdot;
-                    <a href="@VersionHelper.Remotes[0].Replace(" (fetch)", "")" target="_blank">
+                    <a href="@VersionHelper.Remotes[0].Split(".git")[0]" target="_blank">
                         Source Code
                     </a>
                 </span>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -193,7 +193,7 @@
             <div class="ui container">
                 @{
                     string? firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
-                    string? firstRemoteParsedUrl;
+                    string? firstRemoteParsedUrl = null;
 
                     if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("git@"))
                     {
@@ -202,10 +202,6 @@
                     else if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("https://"))
                     {
                         firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
-                    }
-                    else
-                    {
-                        firstRemoteParsedUrl = null;
                     }
                 }
                 <span>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -192,8 +192,13 @@
         <div class="ui black attached inverted segment">
             <div class="ui container">
                 @{
-                    string? firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
+                    string? firstRemoteUnparsedUrl = null;
                     string? firstRemoteParsedUrl = null;
+
+                    if (VersionHelper.Remotes != null)
+                    {
+                        firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
+                    }
 
                     if (firstRemoteUnparsedUrl != null)
                     {

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -192,25 +192,7 @@
         <div class="ui black attached inverted segment">
             <div class="ui container">
                 @{
-                    string? firstRemoteUnparsedUrl = null;
-                    string? firstRemoteParsedUrl = null;
-
-                    if (VersionHelper.Remotes != null)
-                    {
-                        firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
-                    }
-
-                    if (firstRemoteUnparsedUrl != null)
-                    {
-                        if (firstRemoteUnparsedUrl.Contains("git@"))
-                        {
-                            firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();
-                        }
-                        else if (firstRemoteUnparsedUrl.Contains("https://"))
-                        {
-                            firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
-                        }    
-                    }
+                    string? remoteUrl = VersionHelper.DetermineRemoteUrl();
                 }
                 <span>
                     @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)
@@ -224,11 +206,11 @@
                         AGPL-3.0 License
                     </a>
                     &centerdot;
-                    @if (!string.IsNullOrWhiteSpace(firstRemoteParsedUrl))
+                    @if (!string.IsNullOrWhiteSpace(remoteUrl))
                     {
-                        <a href="https://@firstRemoteParsedUrl" target="_blank">
+                        <a href="https://@remoteUrl" target="_blank">
                             Source Code
-                        </a>    
+                        </a>
                     }
                     else
                     {

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -195,13 +195,16 @@
                     string? firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
                     string? firstRemoteParsedUrl = null;
 
-                    if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("git@"))
+                    if (firstRemoteUnparsedUrl != null)
                     {
-                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();    
-                    }
-                    else if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("https://"))
-                    {
-                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
+                        if (firstRemoteUnparsedUrl.Contains("git@"))
+                        {
+                            firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();
+                        }
+                        else if (firstRemoteUnparsedUrl.Contains("https://"))
+                        {
+                            firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
+                        }    
                     }
                 }
                 <span>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -192,7 +192,21 @@
         <div class="ui black attached inverted segment">
             <div class="ui container">
                 @{
-                    string? firstRemoteUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("git@", "https://").Replace(":", "").Replace(".git", "");
+                    string? firstRemoteUnparsedUrl = VersionHelper.Remotes.FirstOrDefault();
+                    string? firstRemoteParsedUrl;
+
+                    if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("git@"))
+                    {
+                        firstRemoteParsedUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("git@", "").Replace(":", "").Split(".git").FirstOrDefault();    
+                    }
+                    else if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("https://"))
+                    {
+                        firstRemoteParsedUrl = VersionHelper.Remotes.FirstOrDefault()?.Replace("https://", "").Split(".git").FirstOrDefault();
+                    }
+                    else
+                    {
+                        firstRemoteParsedUrl = null;
+                    }
                 }
                 <span>
                     @Model.Translate(BaseLayoutStrings.GeneratedBy, VersionHelper.FullVersion)
@@ -206,15 +220,15 @@
                         AGPL-3.0 License
                     </a>
                     &centerdot;
-                    @if (!string.IsNullOrWhiteSpace(firstRemoteUrl))
+                    @if (!string.IsNullOrWhiteSpace(firstRemoteParsedUrl))
                     {
-                        <a href="@firstRemoteUrl" target="_blank">
+                        <a href="https://@firstRemoteParsedUrl" target="_blank">
                             Source Code
                         </a>    
                     }
                     else
                     {
-                        <span class="ui text red">Cannot Determine Remote</span>
+                        <span class="ui text red">Cannot Detect Source Code</span>
                     }
                 </span>
             </div>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -197,7 +197,7 @@
 
                     if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("git@"))
                     {
-                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "").Split(".git").FirstOrDefault();    
+                        firstRemoteParsedUrl = firstRemoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();    
                     }
                     else if (firstRemoteUnparsedUrl != null && firstRemoteUnparsedUrl.Contains("https://"))
                     {

--- a/ProjectLighthouse/Helpers/VersionHelper.cs
+++ b/ProjectLighthouse/Helpers/VersionHelper.cs
@@ -32,11 +32,8 @@ public static class VersionHelper
         }
         catch
         {
-            Logger.Error
-            (
-                "Project Lighthouse was built incorrectly. Please make sure git is available when building.",
-                LogArea.Startup
-            );
+            Logger.Error("Project Lighthouse was built incorrectly. Please make sure git is available when building.",
+                LogArea.Startup);
             CommitHash = "invalid";
             Branch = "invalid";
             CanCheckForUpdates = false;
@@ -44,37 +41,65 @@ public static class VersionHelper
 
         if (!IsDirty) return;
 
-        Logger.Warn
-        (
-            "This is a modified version of Project Lighthouse. " +
-            "Please make sure you are properly disclosing the source code to any users who may be using this instance.",
-            LogArea.Startup
-        );
+        Logger.Warn("This is a modified version of Project Lighthouse. " +
+                    "Please make sure you are properly disclosing the source code to any users who may be using this instance.",
+            LogArea.Startup);
         CanCheckForUpdates = false;
     }
+
+    #nullable enable
+    /// <summary>
+    ///     Determines the URL of the git remote. This doesn't return a complete URL and it's only really used for the
+    ///     "Source Code" hyperlink in the BaseLayout. Use this with caution.
+    /// </summary>
+    public static string? DetermineRemoteUrl()
+    {
+        string? remoteUnparsedUrl = null;
+        string? remoteParsedUrl = null;
+
+        if (Remotes != null) remoteUnparsedUrl = Remotes.FirstOrDefault();
+        if (remoteUnparsedUrl == null) return null;
+
+        if (remoteUnparsedUrl.Contains("git@"))
+        {
+            remoteParsedUrl = remoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();
+        }
+        else if (remoteUnparsedUrl.Contains("https://"))
+        {
+            remoteParsedUrl = remoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
+        }
+
+        return remoteParsedUrl;
+    }
+    #nullable disable
 
     public static string CommitHash { get; set; }
     public static string Branch { get; set; }
     /// <summary>
-    /// The full revision string. States current revision hash and, if not main, the branch.
+    ///     The full revision string. States current revision hash and, if not main, the branch.
     /// </summary>
-    public static string FullRevision { get; set; }
+    private static string FullRevision { get; set; }
     /// <summary>
-    /// The server's branding (environment version) to show to LBP clients. Shows the environment name next to the revision.
+    ///     The server's branding (environment version) to show to LBP clients. Shows the environment name next to the
+    ///     revision.
     /// </summary>
     public static string EnvVer => $"{ServerConfiguration.Instance.Customization.EnvironmentName} {FullRevision}";
-    public static string FullVersion => $"Project Lighthouse {ServerConfiguration.Instance.Customization.EnvironmentName} {Branch}@{CommitHash} {Build}";
-    public static bool IsDirty => CommitHash.EndsWith("-dirty") || CommitsOutOfDate != 1 || CommitHash == "invalid" || Branch == "invalid";
+    public static string FullVersion =>
+        $"Project Lighthouse {ServerConfiguration.Instance.Customization.EnvironmentName} {Branch}@{CommitHash} {Build}";
+    public static bool IsDirty => CommitHash.EndsWith("-dirty") ||
+                                  CommitsOutOfDate != 1 ||
+                                  CommitHash == "invalid" ||
+                                  Branch == "invalid";
     public static int CommitsOutOfDate { get; set; }
     public static bool CanCheckForUpdates { get; set; }
     public static string[] Remotes { get; set; }
 
     public const string Build =
-    #if DEBUG
+        #if DEBUG
         "Debug";
-    #elif RELEASE
+        #elif RELEASE
         "Release";
-    #else
-         "Unknown";
-    #endif
+        #else
+             "Unknown";
+        #endif
 }

--- a/ProjectLighthouse/Helpers/VersionHelper.cs
+++ b/ProjectLighthouse/Helpers/VersionHelper.cs
@@ -52,7 +52,8 @@ public static class VersionHelper
     ///     Determines the URL of the git remote. This doesn't return a complete URL and it's only really used for the
     ///     "Source Code" hyperlink in the BaseLayout. Use this with caution.
     /// </summary>
-    public static string? DetermineRemoteUrl()
+    /// <param name="includePrefix">Include the "https://" prefix in the returned URL.</param>
+    public static string? DetermineRemoteUrl(bool includePrefix = true)
     {
         string? remoteUnparsedUrl = null;
         string? remoteParsedUrl = null;
@@ -66,7 +67,9 @@ public static class VersionHelper
         }
         else if (remoteUnparsedUrl.Contains("https://"))
         {
-            remoteParsedUrl = remoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
+            remoteParsedUrl = includePrefix
+                ? remoteUnparsedUrl.Split(".git").FirstOrDefault()
+                : remoteUnparsedUrl.Replace("https://", "").Split(".git").FirstOrDefault();
         }
 
         return remoteParsedUrl;

--- a/ProjectLighthouse/Helpers/VersionHelper.cs
+++ b/ProjectLighthouse/Helpers/VersionHelper.cs
@@ -49,8 +49,7 @@ public static class VersionHelper
 
     #nullable enable
     /// <summary>
-    ///     Determines the URL of the git remote. This doesn't return a complete URL and it's only really used for the
-    ///     "Source Code" hyperlink in the BaseLayout. Use this with caution.
+    ///     Determines the URL of the git remote.
     /// </summary>
     /// <param name="includePrefix">Include the "https://" prefix in the returned URL.</param>
     public static string? DetermineRemoteUrl(bool includePrefix = true)

--- a/ProjectLighthouse/Helpers/VersionHelper.cs
+++ b/ProjectLighthouse/Helpers/VersionHelper.cs
@@ -62,7 +62,9 @@ public static class VersionHelper
 
         if (remoteUnparsedUrl.Contains("git@"))
         {
-            remoteParsedUrl = remoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();
+            remoteParsedUrl = includePrefix
+                ? remoteUnparsedUrl.Replace("git@", "https://").Replace(":", "/").Split(".git").FirstOrDefault()
+                : remoteUnparsedUrl.Replace("git@", "").Replace(":", "/").Split(".git").FirstOrDefault();
         }
         else if (remoteUnparsedUrl.Contains("https://"))
         {


### PR DESCRIPTION
Adds hyperlinks to the upstream LICENSE file, as well as the active git remote, to help better comply with AGPL's requirements.

<img width="1172" alt="Screenshot 2023-09-30 at 10 57 52 AM" src="https://github.com/LBPUnion/ProjectLighthouse/assets/68549366/d56e37e6-c114-4545-b52e-30856eaa370a">