### PR TITLE
Add checks for resource strings

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -3,6 +3,7 @@ using Discord;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
@@ -41,6 +42,13 @@ public class PhotosController : ControllerBase
 
         GamePhoto? photo = await this.DeserializeBody<GamePhoto>();
         if (photo == null) return this.BadRequest();
+
+        string[] photoHashes =
+        {
+            photo.LargeHash, photo.MediumHash, photo.SmallHash, photo.PlanHash,
+        };
+
+        if (photoHashes.Any(hash => !FileHelper.ResourceExists(hash))) return this.BadRequest();
 
         foreach (PhotoEntity p in this.database.Photos.Where(p => p.CreatorId == token.UserId))
         {

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
@@ -49,7 +49,6 @@ public class ResourcesController : ControllerBase
         return this.NotFound();
     }
 
-    // TODO: check if this is a valid hash
     [HttpPost("upload/{hash}/unattributed")]
     [HttpPost("upload/{hash}")]
     public async Task<IActionResult> UploadResource(string hash)

--- a/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
@@ -83,12 +83,9 @@ public class UserController : ControllerBase
         // ReSharper disable once LoopCanBeConvertedToQuery
         foreach (string? resource in new[]{update.IconHash, update.YayHash, update.MehHash, update.BooHash, update.PlanetHash,})
         {
-            if (resource == "0") continue;
+            if (string.IsNullOrWhiteSpace(resource)) continue;
 
-            if (resource != null && !resource.StartsWith('g') && !FileHelper.ResourceExists(resource))
-            {
-                return this.BadRequest();
-            }
+            if (!FileHelper.ResourceExists(resource)) return this.BadRequest();
         }
 
         if (update.IconHash != null) user.IconHash = update.IconHash;

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -8,7 +8,6 @@ using LBPUnion.ProjectLighthouse.Types.Moderation.Cases;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using IOFile = System.IO.File;
 
 namespace LBPUnion.ProjectLighthouse.Servers.Website.Controllers.Admin;
 
@@ -68,7 +67,7 @@ public class AdminUserController : ControllerBase
             // And finally, attempt to remove the resource from the filesystem. We don't want that taking up space.
             try
             {
-                IOFile.Delete(FileHelper.GetResourcePath(hash));
+                FileHelper.DeleteResource(hash);
                 Logger.Success($"Deleted planet resource {hash}",
                     LogArea.Admin);
             }

--- a/ProjectLighthouse.Tests/Unit/ResourceTests.cs
+++ b/ProjectLighthouse.Tests/Unit/ResourceTests.cs
@@ -10,6 +10,39 @@ namespace LBPUnion.ProjectLighthouse.Tests.Unit;
 [Trait("Category", "Unit")]
 public class ResourceTests
 {
+
+    [Fact]
+    public void IsResourceValid_ReturnsTrue_ForValidResource()
+    {
+        string[] resources = {
+            "g123456", "g123", "98f54143ab4e86b28c3afee0f50f2f51cfb2ed38", "0ebe53fc820a544798000188d39bfda94f53fe37"
+        };
+        Assert.Multiple(() =>
+        {
+            foreach (string resource in resources)
+            {
+                Assert.True(FileHelper.IsResourceValid(resource));
+            }
+        });
+        
+    }
+
+    [Fact]
+    public void IsResourceValid_ReturnsFalse_ForInvalidResource()
+    {
+        string[] resources =
+        {
+            "G0234", "g123456789012334567", "b28c3afee0f50f2f51cfb2ed38", "../Test",
+        };
+        Assert.Multiple(() =>
+        {
+            foreach (string resource in resources)
+            {
+                Assert.False(FileHelper.IsResourceValid(resource));
+            }
+        });
+    }
+
     [Fact]
     public void ShouldNotDeleteResourceFolder()
     {

--- a/ProjectLighthouse/Files/FileHelper.cs
+++ b/ProjectLighthouse/Files/FileHelper.cs
@@ -59,7 +59,7 @@ public static partial class FileHelper
     }
 
     public static bool ResourceExists(string hash) => ResourceRegex().IsMatch(hash) && File.Exists(GetResourcePath(hash));
-    public static bool ImageExists(string hash) => ResourceRegex().IsMatch(hash) && File.Exists(GetImagePath(hash));
+    public static bool ImageExists(string hash) => File.Exists(GetImagePath(hash));
 
     public static void DeleteResource(string hash)
     {

--- a/ProjectLighthouse/Files/FileHelper.cs
+++ b/ProjectLighthouse/Files/FileHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Types.Resources;
 
@@ -9,6 +10,9 @@ namespace LBPUnion.ProjectLighthouse.Files;
 
 public static partial class FileHelper
 {
+    [GeneratedRegex("^(g[0-9]{3,16}|[a-z0-9]{40})$")]
+    private static partial Regex ResourceRegex();
+
     public static readonly string ResourcePath = Path.Combine(Environment.CurrentDirectory, "r");
 
     public static readonly string FullResourcePath = Path.GetFullPath(ResourcePath);
@@ -20,6 +24,8 @@ public static partial class FileHelper
     public static string GetResourcePath(string hash) => Path.Combine(ResourcePath, hash);
 
     public static string GetImagePath(string hash) => Path.Combine(ImagePath, hash);
+
+    public static bool IsResourceValid(string hash) => ResourceRegex().IsMatch(hash);
 
     public static bool IsFileSafe(LbpFile file)
     {
@@ -52,8 +58,8 @@ public static partial class FileHelper
         };
     }
 
-    public static bool ResourceExists(string hash) => File.Exists(GetResourcePath(hash));
-    public static bool ImageExists(string hash) => File.Exists(GetImagePath(hash));
+    public static bool ResourceExists(string hash) => ResourceRegex().IsMatch(hash) && File.Exists(GetResourcePath(hash));
+    public static bool ImageExists(string hash) => ResourceRegex().IsMatch(hash) && File.Exists(GetImagePath(hash));
 
     public static void DeleteResource(string hash)
     {

--- a/ProjectLighthouse/Types/Resources/LbpFile.cs
+++ b/ProjectLighthouse/Types/Resources/LbpFile.cs
@@ -30,7 +30,8 @@ public class LbpFile
 
     public static LbpFile? FromHash(string? hash)
     {
-        if (hash == null) return null;
+        if (hash == null || !FileHelper.IsResourceValid(hash)) return null;
+
         string path = FileHelper.GetResourcePath(hash);
         if (!File.Exists(path)) return null;
 


### PR DESCRIPTION
Pretty self-explanable. This PR prevents people from trying to put payloads in resource hashes like path traversals or HTML escapes. I don't think this needs an entire migration, it should be relatively simple for server owners to fix any occurrences of invalid resources and I don't think the issue is that widespread at the moment.