### PR TITLE
Implement URL slugs 

### DIFF
--- a/ProjectLighthouse.Servers.Website/Extensions/SlugExtensions.cs
+++ b/ProjectLighthouse.Servers.Website/Extensions/SlugExtensions.cs
@@ -10,6 +10,9 @@ public static partial class SlugExtensions
     [GeneratedRegex("[^a-zA-Z0-9 ]")]
     private static partial Regex ValidSlugCharactersRegex();
 
+    [GeneratedRegex(@"[\s]{2,}")]
+    private static partial Regex WhitespaceRegex();
+
     /// <summary>
     /// Generates a URL slug that only contains alphanumeric characters
     /// with spaces replaced with dashes
@@ -19,7 +22,7 @@ public static partial class SlugExtensions
     public static string GenerateSlug(this SlotEntity slot) =>
         slot.Name.Length == 0
             ? "unnamed-level"
-            : ValidSlugCharactersRegex().Replace(HttpUtility.HtmlDecode(slot.Name), "").Replace(" ", "-").ToLower();
+            : WhitespaceRegex().Replace(ValidSlugCharactersRegex().Replace(HttpUtility.HtmlDecode(slot.Name), ""), " ").Replace(" ", "-").ToLower();
 
     /// <summary>
     /// Generates a URL slug for the given user

--- a/ProjectLighthouse.Servers.Website/Extensions/SlugExtensions.cs
+++ b/ProjectLighthouse.Servers.Website/Extensions/SlugExtensions.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+using System.Web;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+
+namespace LBPUnion.ProjectLighthouse.Servers.Website.Extensions;
+
+public static partial class SlugExtensions
+{
+    [GeneratedRegex("[^a-zA-Z0-9 ]")]
+    private static partial Regex ValidSlugCharactersRegex();
+
+    /// <summary>
+    /// Generates a URL slug that only contains alphanumeric characters
+    /// with spaces replaced with dashes
+    /// </summary>
+    /// <param name="slot">The slot to generate the slug for</param>
+    /// <returns>A string containing the url slug for this slot</returns>
+    public static string GenerateSlug(this SlotEntity slot) =>
+        slot.Name.Length == 0
+            ? "unnamed-level"
+            : ValidSlugCharactersRegex().Replace(HttpUtility.HtmlDecode(slot.Name), "").Replace(" ", "-").ToLower();
+
+    /// <summary>
+    /// Generates a URL slug for the given user
+    /// </summary>
+    /// <param name="user">The user to generate the slug for</param>
+    /// <returns>A string containing the url slug for this user</returns>
+    public static string GenerateSlug(this UserEntity user) => user.Username.ToLower();
+}

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/Links/UserLinkPartial.cshtml
@@ -12,7 +12,7 @@
     string userStatus = includeStatus ? Model.GetStatus(Database).ToTranslatedString(language, timeZone) : "";
 }
 
-<a href="/user/@Model.UserId" title="@userStatus" class="user-link">
+<a href="/user/@Model.UserId/@Model.GenerateSlug()" title="@userStatus" class="user-link">
     <img src="/gameAssets/@Model.WebsiteAvatarHash" alt=""/>
 
     @if (Model.IsModerator)

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/SlotCardPartial.cshtml
@@ -53,7 +53,7 @@
             @if (showLink)
             {
                 <h2>
-                    <a href="~/slot/@Model.SlotId">@slotName</a> <i class="@Model.GetLevelLockIcon()"></i>
+                    <a href="~/slot/@Model.SlotId/@Model.GenerateSlug()">@slotName</a> <i class="@Model.GetLevelLockIcon()"></i>
                 </h2>
             }
             else
@@ -68,7 +68,7 @@
             @if (showLink)
             {
                 <h3>
-                    <a href="~/slot/@Model.SlotId">@slotName</a> <i class="@Model.GetLevelLockIcon()"></i>
+                    <a href="~/slot/@Model.SlotId/@Model.GenerateSlug()">@slotName</a> <i class="@Model.GetLevelLockIcon()"></i>
                 </h3>
             }
             else

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/UserCardPartial.cshtml
@@ -22,7 +22,7 @@
         @if (showLink)
         {
             <h2 style="margin-bottom: 2px;">
-                <a href="~/user/@Model.UserId">@Model.Username</a>
+                <a href="~/user/@Model.UserId/@Model.GenerateSlug()">@Model.Username</a>
                     @if (Model.IsModerator)
                     {
                         <span class="profile-tag ui label @Model.PermissionLevel.ToHtmlColor()">

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -1,4 +1,4 @@
-@page "/slot/{id:int}"
+@page "/slot/{id:int}/{slug?}"
 @using System.Web
 @using LBPUnion.ProjectLighthouse.Database
 @using LBPUnion.ProjectLighthouse.Extensions

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Extensions;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
@@ -28,7 +29,7 @@ public class SlotPage : BaseLayout
     public SlotPage(DatabaseContext database) : base(database)
     {}
 
-    public async Task<IActionResult> OnGet([FromRoute] int id)
+    public async Task<IActionResult> OnGet([FromRoute] int id, string? slug)
     {
         SlotEntity? slot = await this.Database.Slots.Include(s => s.Creator)
             .Where(s => s.Type == SlotType.User || (this.User != null && this.User.PermissionLevel >= PermissionLevel.Moderator))
@@ -44,6 +45,12 @@ public class SlotPage : BaseLayout
 
         if ((slot.Hidden || slot.SubLevel && (this.User == null && this.User != slot.Creator)) && !(this.User?.IsModerator ?? false))
             return this.NotFound();
+
+        string slotSlug = slot.GenerateSlug();
+        if (slug == null || slotSlug != slug)
+        {
+            return this.Redirect($"~/slot/{id}/{slotSlug}");
+        }
 
         this.Slot = slot;
 

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -1,4 +1,4 @@
-@page "/user/{userId:int}"
+@page "/user/{userId:int}/{slug?}"
 @using System.Web
 @using LBPUnion.ProjectLighthouse.Extensions
 @using LBPUnion.ProjectLighthouse.Localization.StringLists

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.Website.Extensions;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
@@ -38,10 +39,16 @@ public class UserPage : BaseLayout
     public UserPage(DatabaseContext database) : base(database)
     { }
 
-    public async Task<IActionResult> OnGet([FromRoute] int userId)
+    public async Task<IActionResult> OnGet([FromRoute] int userId, string? slug)
     {
         this.ProfileUser = await this.Database.Users.FirstOrDefaultAsync(u => u.UserId == userId);
         if (this.ProfileUser == null) return this.NotFound();
+
+        string userSlug = this.ProfileUser.GenerateSlug();
+        if (slug == null || userSlug != slug)
+        {
+            return this.Redirect($"~/user/{userId}/{userSlug}");
+        }
 
         bool isAuthenticated = this.User != null;
         bool isOwner = this.ProfileUser == this.User || this.User != null && this.User.IsModerator;


### PR DESCRIPTION
Slugs are generated by stripping out all characters that aren't alphanumeric (a-Z, 0-9, and spaces) and replacing spaces with dashes then finally transforming everything into lowercase so "3-D platformer level" gets turned into "3d-platformer-level"
and "<UPDATED 3/7/70> Test & Buy" gets turned into "updated-3770-test-buy"

<img width="569" alt="example of slug url" src="https://github.com/LBPUnion/ProjectLighthouse/assets/16675503/d4691ade-7ff5-438a-a5c1-62d8b56e01d2">

Closes #146