### PR TITLE
Missing digest message change

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
+++ b/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
@@ -90,7 +90,7 @@ public class GameServerStartup
         {
             Logger.Warn
             (
-                "The serverDigestKey configuration option wasn't set, so digest headers won't be set or verified. This will prevent LBP 1, and LBP 3 from working, and may break features in the other games (i.e Dive in). " +
+                "The serverDigestKey configuration option wasn't set, so digest headers won't be set or verified. This will prevent LBP 1 and LBP 3 from working, and may break features in the other games (i.e Dive In). " +
                 "To increase security, it is recommended that you find and set this variable.",
                 LogArea.Startup
             );

--- a/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
+++ b/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
@@ -90,7 +90,7 @@ public class GameServerStartup
         {
             Logger.Warn
             (
-                "The serverDigestKey configuration option wasn't set, so digest headers won't be set or verified. This will also prevent LBP 1, LBP 2, and LBP Vita from working. " +
+                "The serverDigestKey configuration option wasn't set, so digest headers won't be set or verified. This will prevent LBP 1, and LBP 3 from working, and may break features in the other games (i.e Dive in). " +
                 "To increase security, it is recommended that you find and set this variable.",
                 LogArea.Startup
             );


### PR DESCRIPTION
This PR changes the message that shows when the digestKey has not been set to better reflect what will/won't work if left unset.