### PR TITLE
Miscellaneous website/moderation/notification fixes

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -89,16 +89,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
 
         StringBuilder builder = new();
 
-        // ReSharper disable once ForCanBeConvertedToForeach
-        // Suppressing this because we need to modify the list while iterating over it.
-        for (int i = 0; i < notifications.Count; i++)
+        foreach (NotificationEntity notification in notifications)
         {
-            NotificationEntity n = notifications[i];
-
             builder.AppendLine(LighthouseSerializer.Serialize(this.HttpContext.RequestServices,
-                GameNotification.CreateFromEntity(n)));
+                GameNotification.CreateFromEntity(notification)));
 
-            n.IsDismissed = true;
+            notification.IsDismissed = true;
         }
 
         await this.database.SaveChangesAsync();

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml.cs
@@ -39,11 +39,11 @@ public class SlotPage : BaseLayout
 
         bool isAuthenticated = this.User != null;
         bool isOwner = slot.Creator == this.User || this.User != null && this.User.IsModerator;
-        
+
         // Determine if user can view slot according to creator's privacy settings
         this.CanViewSlot = slot.Creator.LevelVisibility.CanAccess(isAuthenticated, isOwner);
 
-        if ((slot.Hidden || slot.SubLevel && (this.User == null && this.User != slot.Creator)) && !(this.User?.IsModerator ?? false))
+        if ((slot.Hidden || slot.SubLevel && (this.User == null || this.User != slot.Creator)) && !(this.User?.IsModerator ?? false))
             return this.NotFound();
 
         string slotSlug = slot.GenerateSlug();
@@ -60,7 +60,7 @@ public class SlotPage : BaseLayout
                 from blockedProfile in this.Database.BlockedProfiles
                 where blockedProfile.UserId == this.User.UserId
                 select blockedProfile.BlockedUserId).ToListAsync();
-        
+
         this.CommentsEnabled = ServerConfiguration.Instance.UserGeneratedContentLimits.LevelCommentsEnabled && this.Slot.CommentsEnabled;
         if (this.CommentsEnabled)
         {

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml.cs
@@ -52,7 +52,7 @@ public class UserPage : BaseLayout
 
         bool isAuthenticated = this.User != null;
         bool isOwner = this.ProfileUser == this.User || this.User != null && this.User.IsModerator;
-        
+
         // Determine if user can view profile according to profileUser's privacy settings
         this.CanViewProfile = this.ProfileUser.ProfileVisibility.CanAccess(isAuthenticated, isOwner);
         this.CanViewSlots = this.ProfileUser.LevelVisibility.CanAccess(isAuthenticated, isOwner);
@@ -68,6 +68,7 @@ public class UserPage : BaseLayout
         this.Slots = await this.Database.Slots.Include(p => p.Creator)
             .OrderByDescending(s => s.LastUpdated)
             .Where(p => p.CreatorId == userId)
+            .Where(p => p.Creator != null && (!p.SubLevel || p.Creator == this.User))
             .Take(10)
             .ToListAsync();
 

--- a/ProjectLighthouse/Administration/Maintenance/RepeatingTasks/DismissExpiredCasesTask.cs
+++ b/ProjectLighthouse/Administration/Maintenance/RepeatingTasks/DismissExpiredCasesTask.cs
@@ -33,6 +33,9 @@ public class DismissExpiredCasesTask : IRepeatingTask
         {
             @case.DismissedAt = DateTime.UtcNow;
             @case.DismisserUsername = "maintenance task";
+
+            @case.Processed = false;
+
             Logger.Info($"Dismissed expired case {@case.CaseId}", LogArea.Maintenance);
         }
 


### PR DESCRIPTION
This PR addresses a few minor issues and fixes a few things.

* Sub-levels would be displayed on a user's profile when logged out
* Fixes an issue when trying to directly access a sub-level page on the website as the slot creator
* Mark automatically dismissed cases as unprocessed so the repeating task will perform case actions
* Use a foreach for notifications
  * It was thought that modifying a collection item while iterating over the list would throw an exception but this is exactly what the automatic case dismissal repeating task does. Tested this and it works perfectly fine.