### PR TITLE
Show rootlevel hash to moderators on slot page

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -72,7 +72,9 @@ else
         <div class="eight wide column">
             <div class="ui blue segment">
                 <h2>Description</h2>
-                <p style="overflow-wrap: anywhere">@HttpUtility.HtmlDecode(string.IsNullOrEmpty(Model.Slot?.Description) ? "This level has no description." : Model.Slot.Description)</p>
+                <p style="overflow-wrap: anywhere">
+                    @HttpUtility.HtmlDecode(string.IsNullOrEmpty(Model.Slot?.Description) ? "This level has no description." : Model.Slot.Description)
+                </p>
             </div>
         </div>
         @if (isMobile)
@@ -80,6 +82,18 @@ else
             <br/>
         }
         <div class="eight wide column">
+            @if (Model.User != null && Model.User.IsModerator)
+            {
+                <div class="ui green segment">
+                    <div>
+                        <b>Level Hash:</b>
+                        <code>
+                            @HttpUtility.HtmlDecode(string.IsNullOrWhiteSpace(Model.Slot?.RootLevel) ? "No root level." : Model.Slot.RootLevel)
+                        </code>
+                    </div>
+                    <small>You can see this because you are a moderator.</small>
+                </div>
+            }
             <div class="ui red segment">
                 <h2>Tags</h2>
                 @{
@@ -92,6 +106,7 @@ else
                     {
                         authorLabels = Model.Slot?.AuthorLabels.Split(",", StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
                     }
+
                     if (authorLabels.Length == 0)
                     {
                         <p>This level has no tags.</p>
@@ -227,7 +242,7 @@ else
                 <span>Delete</span>
             </div>
         </a>
-        
+
         @if (!Model.Slot!.Hidden)
         {
             <a href="/moderation/newCase?type=@((int)CaseType.LevelHide)&affectedId=@Model.Slot?.SlotId">
@@ -237,7 +252,7 @@ else
                 </div>
             </a>
         }
-        
+
         @if (!Model.Slot!.InitiallyLocked && !Model.Slot!.LockedByModerator)
         {
             <a href="/moderation/newCase?type=@((int)CaseType.LevelLock)&affectedId=@Model.Slot?.SlotId">
@@ -247,7 +262,7 @@ else
                 </div>
             </a>
         }
-        
+
         @if (Model.Slot!.CommentsEnabled)
         {
             <a class="ui yellow button" href="/moderation/newCase?type=@((int)CaseType.LevelDisableComments)&affectedId=@Model.Slot?.SlotId">
@@ -284,7 +299,7 @@ function setVisible(e){
     }
     // unhide content
     eTarget.style.display = "";
-    
+
     e.classList.add("active");
 }
 
@@ -303,7 +318,7 @@ if (selectedElement != null) {
     while (selectedElement != null && !selectedElement.classList.contains("lh-content")){
         selectedElement = selectedElement.parentElement;
     }
-    
+
     let sidebarEle = document.querySelector("[target=" + selectedElement.id + "]")
     setVisible(sidebarEle);
 }


### PR DESCRIPTION
Self-explanatory PR. Adds a box above the level tags with the rootlevel hash, displayed to mods and admins. Also removes whitespace in the modified file (Rider automated)