### PR TITLE
Use UtcNow instead of Now for internal time keeping

### DIFF
--- a/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/UserEndpoints.cs
@@ -109,7 +109,7 @@ public class UserEndpoints : ApiEndpointController
 
         RegistrationTokenEntity token = new()
         {
-            Created = DateTime.Now,
+            Created = DateTime.UtcNow,
             Token = CryptoHelper.GenerateAuthToken(),
             Username = username,
         };

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationCaseController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationCaseController.cs
@@ -26,7 +26,7 @@ public class ModerationCaseController : ControllerBase
         ModerationCaseEntity? @case = await this.database.Cases.FirstOrDefaultAsync(c => c.CaseId == id);
         if (@case == null) return this.NotFound();
         
-        @case.DismissedAt = DateTime.Now;
+        @case.DismissedAt = DateTime.UtcNow;
         @case.DismisserId = user.UserId;
         @case.DismisserUsername = user.Username;
         

--- a/ProjectLighthouse.Servers.Website/Pages/Email/CompleteEmailVerificationPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Email/CompleteEmailVerificationPage.cshtml.cs
@@ -30,7 +30,7 @@ public class CompleteEmailVerificationPage : BaseLayout
 
         UserEntity user = await this.Database.Users.FirstAsync(u => u.UserId == emailVerifyToken.UserId);
 
-        if (DateTime.Now > emailVerifyToken.ExpiresAt)
+        if (DateTime.UtcNow > emailVerifyToken.ExpiresAt)
         {
             this.Error = "This token has expired";
             return this.Page();
@@ -52,7 +52,7 @@ public class CompleteEmailVerificationPage : BaseLayout
         // if user's account was created automatically
         WebTokenEntity webToken = new()
         {
-            ExpiresAt = DateTime.Now.AddDays(7),
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
             Verified = true,
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),

--- a/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/LoginForm.cshtml.cs
@@ -87,7 +87,7 @@ public class LoginForm : BaseLayout
         {
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now + TimeSpan.FromDays(7),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromDays(7),
             Verified = !ServerConfiguration.Instance.TwoFactorConfiguration.TwoFactorEnabled || !user.IsTwoFactorSetup,
         };
 

--- a/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Login/RegisterForm.cshtml.cs
@@ -89,7 +89,7 @@ public class RegisterForm : BaseLayout
         {
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now + TimeSpan.FromDays(7),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromDays(7),
         };
 
         this.Database.WebTokens.Add(webToken);

--- a/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/Moderation/NewCasePage.cshtml.cs
@@ -98,7 +98,7 @@ public class NewCasePage : BaseLayout
             Reason = reason,
             ModeratorNotes = modNotes,
             ExpiresAt = expires,
-            CreatedAt = DateTime.Now,
+            CreatedAt = DateTime.UtcNow,
             CreatorId = user.UserId,
             CreatorUsername = user.Username,
             AffectedId = affectedId.Value,

--- a/ProjectLighthouse.Tests.WebsiteTests/Integration/AdminTests.cs
+++ b/ProjectLighthouse.Tests.WebsiteTests/Integration/AdminTests.cs
@@ -28,7 +28,7 @@ public class AdminTests : LighthouseWebTest
         {
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now + TimeSpan.FromHours(1),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromHours(1),
             Verified = true,
         };
 
@@ -55,7 +55,7 @@ public class AdminTests : LighthouseWebTest
         {
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now + TimeSpan.FromHours(1),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromHours(1),
             Verified = true,
         };
 

--- a/ProjectLighthouse.Tests.WebsiteTests/Integration/AuthenticationTests.cs
+++ b/ProjectLighthouse.Tests.WebsiteTests/Integration/AuthenticationTests.cs
@@ -89,7 +89,7 @@ public class AuthenticationTests : LighthouseWebTest
         {
             UserId = user.UserId,
             UserToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now + TimeSpan.FromHours(1),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromHours(1),
             Verified = true,
         };
 

--- a/ProjectLighthouse/Administration/Maintenance/Commands/CreateAPIKeyCommand.cs
+++ b/ProjectLighthouse/Administration/Maintenance/Commands/CreateAPIKeyCommand.cs
@@ -29,7 +29,7 @@ public class CreateApiKeyCommand : ICommand
             key.Description = "<no description specified>";
         }
         key.Key = CryptoHelper.GenerateAuthToken();
-        key.Created = DateTime.Now;
+        key.Created = DateTime.UtcNow;
         DatabaseContext database = provider.GetRequiredService<DatabaseContext>();
         await database.APIKeys.AddAsync(key);
         await database.SaveChangesAsync();

--- a/ProjectLighthouse/Administration/Maintenance/MaintenanceHelper.cs
+++ b/ProjectLighthouse/Administration/Maintenance/MaintenanceHelper.cs
@@ -117,7 +117,7 @@ public static class MaintenanceHelper
         CompletedMigrationEntity completedMigration = new()
         {
             MigrationName = migrationTask.GetType().Name,
-            RanAt = DateTime.Now,
+            RanAt = DateTime.UtcNow,
         };
 
         database.CompletedMigrations.Add(completedMigration);

--- a/ProjectLighthouse/Database/DatabaseContext.GameTokens.cs
+++ b/ProjectLighthouse/Database/DatabaseContext.GameTokens.cs
@@ -33,7 +33,7 @@ public partial class DatabaseContext
 
         if (token == null) return null;
 
-        if (DateTime.Now <= token.ExpiresAt) return token;
+        if (DateTime.UtcNow <= token.ExpiresAt) return token;
 
         this.Remove(token);
         await this.SaveChangesAsync();

--- a/ProjectLighthouse/Database/DatabaseContext.Utils.cs
+++ b/ProjectLighthouse/Database/DatabaseContext.Utils.cs
@@ -72,7 +72,7 @@ public partial class DatabaseContext
             Platform = npTicket.Platform,
             TicketHash = npTicket.TicketHash,
             // we can get away with a low expiry here since LBP will just get a new token everytime it gets 403'd
-            ExpiresAt = DateTime.Now + TimeSpan.FromHours(1),
+            ExpiresAt = DateTime.UtcNow + TimeSpan.FromHours(1),
         };
 
         this.GameTokens.Add(gameToken);

--- a/ProjectLighthouse/Database/DatabaseContext.WebTokens.cs
+++ b/ProjectLighthouse/Database/DatabaseContext.WebTokens.cs
@@ -26,7 +26,7 @@ public partial class DatabaseContext
         WebTokenEntity? token = this.WebTokens.FirstOrDefault(t => t.UserToken == lighthouseToken);
         if (token == null) return null;
 
-        if (DateTime.Now <= token.ExpiresAt) return this.Users.FirstOrDefault(u => u.UserId == token.UserId);
+        if (DateTime.UtcNow <= token.ExpiresAt) return this.Users.FirstOrDefault(u => u.UserId == token.UserId);
 
         this.Remove(token);
         this.SaveChanges();
@@ -48,7 +48,7 @@ public partial class DatabaseContext
         WebTokenEntity? token = this.WebTokens.FirstOrDefault(t => t.UserToken == lighthouseToken);
         if (token == null) return null;
 
-        if (DateTime.Now <= token.ExpiresAt) return token;
+        if (DateTime.UtcNow <= token.ExpiresAt) return token;
 
         this.Remove(token);
         this.SaveChanges();
@@ -65,7 +65,7 @@ public partial class DatabaseContext
             await this.PasswordResetTokens.FirstOrDefaultAsync(token => token.ResetToken == resetToken);
         if (token == null) return null;
 
-        if (token.Created >= DateTime.Now.AddHours(-1))
+        if (token.Created >= DateTime.UtcNow.AddHours(-1))
             return await this.Users.FirstOrDefaultAsync(user => user.UserId == token.UserId);
 
         this.PasswordResetTokens.Remove(token);
@@ -81,7 +81,7 @@ public partial class DatabaseContext
         RegistrationTokenEntity? token = this.RegistrationTokens.FirstOrDefault(t => t.Token == tokenString);
         if (token == null) return false;
 
-        if (token.Created >= DateTime.Now.AddDays(-7)) return true;
+        if (token.Created >= DateTime.UtcNow.AddDays(-7)) return true;
 
         this.RegistrationTokens.Remove(token);
         this.SaveChanges();
@@ -92,7 +92,7 @@ public partial class DatabaseContext
 
     public async Task RemoveExpiredTokens()
     {
-        List<GameTokenEntity> expiredTokens = await this.GameTokens.Where(t => DateTime.Now > t.ExpiresAt).ToListAsync(); 
+        List<GameTokenEntity> expiredTokens = await this.GameTokens.Where(t => DateTime.UtcNow > t.ExpiresAt).ToListAsync(); 
         foreach (GameTokenEntity token in expiredTokens)
         {
             UserEntity? user = await this.Users.FirstOrDefaultAsync(u => u.UserId == token.UserId);
@@ -100,10 +100,10 @@ public partial class DatabaseContext
         }
         await this.SaveChangesAsync();
 
-        await this.GameTokens.RemoveWhere(t => DateTime.Now > t.ExpiresAt);
-        await this.WebTokens.RemoveWhere(t => DateTime.Now > t.ExpiresAt);
-        await this.EmailVerificationTokens.RemoveWhere(t => DateTime.Now > t.ExpiresAt);
-        await this.EmailSetTokens.RemoveWhere(t => DateTime.Now > t.ExpiresAt);
+        await this.GameTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
+        await this.WebTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
+        await this.EmailVerificationTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
+        await this.EmailSetTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
     }
 
     public async Task RemoveRegistrationToken(string? tokenString)

--- a/ProjectLighthouse/Helpers/EmailHelper.cs
+++ b/ProjectLighthouse/Helpers/EmailHelper.cs
@@ -48,7 +48,7 @@ public static class SMTPHelper
 
         PasswordResetTokenEntity token = new()
         {
-            Created = DateTime.Now,
+            Created = DateTime.UtcNow,
             UserId = user.UserId,
             ResetToken = CryptoHelper.GenerateAuthToken(),
         };
@@ -90,7 +90,7 @@ public static class SMTPHelper
             UserId = user.UserId,
             User = user,
             EmailToken = CryptoHelper.GenerateAuthToken(),
-            ExpiresAt = DateTime.Now.AddHours(6),
+            ExpiresAt = DateTime.UtcNow.AddHours(6),
         };
 
         database.EmailVerificationTokens.Add(verifyToken);

--- a/ProjectLighthouse/Types/Entities/Moderation/ModerationCaseEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Moderation/ModerationCaseEntity.cs
@@ -28,7 +28,7 @@ public class ModerationCaseEntity
     public DateTime CreatedAt { get; set; }
     
     public DateTime? ExpiresAt { get; set; }
-    public bool Expired => this.ExpiresAt != null && this.ExpiresAt < DateTime.Now;
+    public bool Expired => this.ExpiresAt != null && this.ExpiresAt < DateTime.UtcNow;
 
     public DateTime? DismissedAt { get; set; }
     public bool Dismissed => this.DismissedAt != null;


### PR DESCRIPTION
`DateTime.Now` uses local machine time which would potentially cause discrepancies with timekeeping for token or case expirations.