### PR TITLE
Migrate to SQLite EF provider for testing

### DIFF
--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/CommentControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/CommentControllerTests.cs
@@ -94,7 +94,7 @@ public class CommentControllerTests
                 Type = SlotType.User,
             },
         };
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[]{slots,});
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(slots);
 
         CommentController commentController = new(dbMock);
         commentController.SetupTestController("<comment><message>test</message></comment>");
@@ -122,7 +122,7 @@ public class CommentControllerTests
                 Type = SlotType.Developer,
             },
         };
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[] { slots, });
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(slots);
 
         CommentController commentController = new(dbMock);
         commentController.SetupTestController("<comment><message>test</message></comment>");

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/MessageControllerTests.cs
@@ -205,7 +205,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
     {
         List<UserEntity> users = new()
         {
-            MockHelper.GetUnitTestUser(),
             new UserEntity
             {
                 UserId = 2,
@@ -259,10 +258,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>." + "\nuni
     {
         UserEntity unitTestUser = MockHelper.GetUnitTestUser();
         unitTestUser.EmailAddressVerified = true;
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new List<UserEntity>
-        {
-            unitTestUser,
-        });
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase();
 
         Mock<IMailService> mailMock = getMailServiceMock();
 

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/SlotControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/SlotControllerTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Database;
@@ -57,26 +57,29 @@ public class SlotControllerTests
         };
         List<UserEntity> users = new()
         {
-            MockHelper.GetUnitTestUser(),
             new UserEntity
             {
                 Username = "bytest",
                 UserId = 2,
             },
+            new UserEntity
+            {
+                Username = "user3",
+                UserId = 3,
+            },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new IList[]
-        {
-            slots, users,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots, users);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
         IActionResult result = await slotsController.SlotsBy("bytest");
 
         const int expectedElements = 2;
+        HashSet<int> expectedSlotIds = new(){1, 2,};
 
         GenericSlotResponse slotResponse = result.CastTo<OkObjectResult, GenericSlotResponse>();
         Assert.Equal(expectedElements, slotResponse.Slots.Count);
+        Assert.Equal(expectedSlotIds, slotResponse.Slots.OfType<GameUserSlot>().Select(s => s.SlotId).ToHashSet());
     }
 
     [Fact]
@@ -105,17 +108,13 @@ public class SlotControllerTests
         };
         List<UserEntity> users = new()
         {
-            MockHelper.GetUnitTestUser(),
             new UserEntity
             {
                 Username = "bytest",
                 UserId = 2,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new IList[]
-        {
-            slots, users,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots, users);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -143,13 +142,11 @@ public class SlotControllerTests
         {
             new SlotEntity
             {
+                CreatorId = 1,
                 SlotId = 2,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -165,14 +162,12 @@ public class SlotControllerTests
         {
             new SlotEntity
             {
+                CreatorId = 1,
                 SlotId = 2,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -195,13 +190,11 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanetVita,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new IList[]
-        {
-            slots, tokens,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots, tokens);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController(token);
 
@@ -224,13 +217,11 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet1,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new IList[]
-        {
-            slots, tokens,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots, tokens);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController(token);
 
@@ -263,10 +254,7 @@ public class SlotControllerTests
                 SubLevel = false,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -283,14 +271,11 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 27,
-                CreatorId = 4,
+                CreatorId = 1,
                 Hidden = true,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -307,13 +292,11 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 27,
+                CreatorId = 1,
                 Type = SlotType.Developer,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -330,11 +313,11 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 27,
-                CreatorId = 4,
+                CreatorId = 1,
                 SubLevel = true,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new []{slots,});
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController slotsController = new(db);
         slotsController.SetupTestController();
 
@@ -353,14 +336,12 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 1,
+                CreatorId = 1,
                 InternalSlotId = 25,
                 Type = SlotType.Developer,
             },
         };
-        DatabaseContext db = await MockHelper.GetTestDatabase(new[]
-        {
-            slots,
-        });
+        DatabaseContext db = await MockHelper.GetTestDatabase(slots);
         SlotsController controller = new(db);
         controller.SetupTestController();
 
@@ -405,31 +386,32 @@ public class SlotControllerTests
         roomMutex.WaitOne();
         try
         {
-            DatabaseContext db = await MockHelper.GetTestDatabase(new[]
+            DatabaseContext db = await MockHelper.GetTestDatabase(new List<SlotEntity>
             {
-                new List<SlotEntity>
+                new()
                 {
-                    new()
-                    {
-                        SlotId = 1,
-                        Type = SlotType.User,
-                    },
-                    new()
-                    {
-                        SlotId = 2,
-                        Type = SlotType.User,
-                    },
-                    new()
-                    {
-                        SlotId = 3,
-                        Type = SlotType.User,
-                    },
-                    new()
-                    {
-                        SlotId = 4,
-                        Type = SlotType.Developer,
-                        InternalSlotId = 10,
-                    },
+                    SlotId = 1,
+                    CreatorId = 1,
+                    Type = SlotType.User,
+                },
+                new()
+                {
+                    SlotId = 2,
+                    CreatorId = 1,
+                    Type = SlotType.User,
+                },
+                new()
+                {
+                    SlotId = 3,
+                    CreatorId = 1,
+                    Type = SlotType.User,
+                },
+                new()
+                {
+                    SlotId = 4,
+                    CreatorId = 1,
+                    Type = SlotType.Developer,
+                    InternalSlotId = 10,
                 },
             });
             SlotsController controller = new(db);
@@ -466,16 +448,14 @@ public class SlotControllerTests
         roomMutex.WaitOne();
         try
         {
-            DatabaseContext db = await MockHelper.GetTestDatabase(new[]
+            DatabaseContext db = await MockHelper.GetTestDatabase(new List<SlotEntity>
             {
-                new List<SlotEntity>
+                new()
                 {
-                    new()
-                    {
-                        SlotId = 4,
-                        Type = SlotType.Developer,
-                        InternalSlotId = 10,
-                    },
+                    SlotId = 4,
+                    CreatorId = 1,
+                    Type = SlotType.Developer,
+                    InternalSlotId = 10,
                 },
             });
             SlotsController controller = new(db);

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/SlotControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/SlotControllerTests.cs
@@ -250,7 +250,7 @@ public class SlotControllerTests
             new SlotEntity
             {
                 SlotId = 27,
-                CreatorId = 4,
+                CreatorId = 1,
                 SubLevel = false,
             },
         };

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/StatisticsControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/StatisticsControllerTests.cs
@@ -40,18 +40,21 @@ public class StatisticsControllerTests
             new SlotEntity
             {
                 SlotId = 1,
+                CreatorId = 1,
             },
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
             },
             new SlotEntity
             {
                 SlotId = 3,
+                CreatorId = 1,
                 TeamPick = true,
             },
         };
-        await using DatabaseContext db = await MockHelper.GetTestDatabase(new []{slots,});
+        await using DatabaseContext db = await MockHelper.GetTestDatabase(slots);
 
         StatisticsController statsController = new(db);
         statsController.SetupTestController();
@@ -74,21 +77,24 @@ public class StatisticsControllerTests
             new SlotEntity
             {
                 SlotId = 1,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
             new SlotEntity
             {
                 SlotId = 3,
+                CreatorId = 1,
                 TeamPick = true,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
         };
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[]{slots,});
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(slots);
 
         StatisticsController statsController = new(dbMock);
         statsController.SetupTestController();
@@ -111,21 +117,24 @@ public class StatisticsControllerTests
             new SlotEntity
             {
                 SlotId = 1,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet1,
             },
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet1,
             },
             new SlotEntity
             {
                 SlotId = 3,
+                CreatorId = 1,
                 TeamPick = true,
                 GameVersion = GameVersion.LittleBigPlanet1,
             },
         };
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[] {slots,});
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(slots);
 
         StatisticsController statsController = new(dbMock);
         statsController.SetupTestController();
@@ -146,21 +155,24 @@ public class StatisticsControllerTests
             new SlotEntity
             {
                 SlotId = 1,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
             new SlotEntity
             {
                 SlotId = 2,
+                CreatorId = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
             new SlotEntity
             {
                 SlotId = 3,
+                CreatorId = 1,
                 TeamPick = true,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
         }; 
-        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[] {slots,});
+        await using DatabaseContext dbMock = await MockHelper.GetTestDatabase(slots);
 
         StatisticsController statsController = new(dbMock);
         statsController.SetupTestController();

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Middlewares/DigestMiddlewareTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Middlewares/DigestMiddlewareTests.cs
@@ -71,7 +71,8 @@ public class DigestMiddlewareTests
 
         const int expectedCode = 403;
 
-        Assert.Equal(expectedCode, context.Response.StatusCode);
+        Assert.True(expectedCode == context.Response.StatusCode,
+            "The digest middleware accepted the request when it shouldn't have (are you running this test in Debug mode?)");
         Assert.False(context.Response.Headers.TryGetValue("X-Digest-A", out _));
         Assert.False(context.Response.Headers.TryGetValue("X-Digest-B", out _));
     }

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Middlewares/SetLastContactMiddlewareTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Middlewares/SetLastContactMiddlewareTests.cs
@@ -87,7 +87,7 @@ public class SetLastContactMiddlewareTests
             },
         };
 
-        DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[]{lastContacts,});
+        DatabaseContext dbMock = await MockHelper.GetTestDatabase(lastContacts);
 
         await middleware.InvokeAsync(context, dbMock);
 
@@ -132,10 +132,7 @@ public class SetLastContactMiddlewareTests
         };
         tokens[0].GameVersion = GameVersion.LittleBigPlanet2;
 
-        DatabaseContext dbMock = await MockHelper.GetTestDatabase(new[]
-        {
-            tokens,
-        });
+        DatabaseContext dbMock = await MockHelper.GetTestDatabase(tokens);
 
         await middleware.InvokeAsync(context, dbMock);
 

--- a/ProjectLighthouse.Tests/ProjectLighthouse.Tests.csproj
+++ b/ProjectLighthouse.Tests/ProjectLighthouse.Tests.csproj
@@ -30,7 +30,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Moq" Version="4.20.69" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.13" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ProjectLighthouse.Tests/Unit/ModerationTests.cs
+++ b/ProjectLighthouse.Tests/Unit/ModerationTests.cs
@@ -19,6 +19,7 @@ public class ModerationTests
         ModerationCaseEntity @case = new()
         {
             CaseId = 1,
+            CreatorId = 1,
             ExpiresAt = DateTime.UnixEpoch,
             CreatorUsername = "unitTestUser",
         };
@@ -41,6 +42,7 @@ public class ModerationTests
         ModerationCaseEntity @case = new()
         {
             CaseId = 2,
+            CreatorId = 1,
             ExpiresAt = DateTime.UtcNow.AddHours(1),
             CreatorUsername = "unitTestUser",
         };
@@ -63,6 +65,7 @@ public class ModerationTests
         ModerationCaseEntity @case = new()
         {
             CaseId = 3,
+            CreatorId = 1,
             ExpiresAt = DateTime.UnixEpoch,
             DismissedAt = DateTime.UnixEpoch,
             CreatorUsername = "unitTestUser",


### PR DESCRIPTION
Currently, we use the InMemory EF provider which has some issues like not enforcing referential integrity (a level can exist without a creator). It also doesn't detect potential issues with database schema. Switching to in-memory SQLite fixes both these issues and will make unit tests more realistic.