### PR TITLE
Rename the database model snapshot and move it to the actual migrations folder

### DIFF
--- a/ProjectLighthouse/Migrations/DatabaseContextModelSnapshot.cs
+++ b/ProjectLighthouse/Migrations/DatabaseContextModelSnapshot.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ProjectLighthouse.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseModelSnapshot : ModelSnapshot
+    partial class DatabaseContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
Removes the dreaded `ProjectLighthouse\ProjectLighthouse\Migrations` folder. This should have also been renamed when we renamed the `Database` class to `DatabaseContext` since the format of the class is `<YourContext>ModelSnapshot.cs`