### PR TITLE
Prevent password reset spam

### DIFF
--- a/ProjectLighthouse/Database/DatabaseContext.WebTokens.cs
+++ b/ProjectLighthouse/Database/DatabaseContext.WebTokens.cs
@@ -104,6 +104,7 @@ public partial class DatabaseContext
         await this.WebTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
         await this.EmailVerificationTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
         await this.EmailSetTokens.RemoveWhere(t => DateTime.UtcNow > t.ExpiresAt);
+        await this.PasswordResetTokens.RemoveWhere(t => DateTime.UtcNow > t.Created.AddDays(1));
     }
 
     public async Task RemoveRegistrationToken(string? tokenString)

--- a/ProjectLighthouse/Helpers/EmailHelper.cs
+++ b/ProjectLighthouse/Helpers/EmailHelper.cs
@@ -62,7 +62,7 @@ public static class SMTPHelper
                              "A request to reset your account's password was issued. If this wasn't you, this can probably be ignored.\n\n" +
                              $"If this was you, your {ServerConfiguration.Instance.Customization.ServerName} password can be reset at the following link:\n" +
                              $"{ServerConfiguration.Instance.ExternalUrl}/passwordReset?token={token.ResetToken}\n\n" + 
-                             "This link will expire in one hour";
+                             "This link will expire in 24 hours";
 
         await mail.SendEmailAsync(user.EmailAddress, $"Project Lighthouse Password Reset Request for {user.Username}", messageBody);
 

--- a/ProjectLighthouse/Helpers/EmailHelper.cs
+++ b/ProjectLighthouse/Helpers/EmailHelper.cs
@@ -46,6 +46,8 @@ public static class SMTPHelper
     {
         if (!CanSendMail(user)) return;
 
+        if (await database.PasswordResetTokens.CountAsync(t => t.UserId == user.UserId) > 0) return;
+
         PasswordResetTokenEntity token = new()
         {
             Created = DateTime.UtcNow,
@@ -59,7 +61,8 @@ public static class SMTPHelper
         string messageBody = $"Hello, {user.Username}.\n\n" +
                              "A request to reset your account's password was issued. If this wasn't you, this can probably be ignored.\n\n" +
                              $"If this was you, your {ServerConfiguration.Instance.Customization.ServerName} password can be reset at the following link:\n" +
-                             $"{ServerConfiguration.Instance.ExternalUrl}/passwordReset?token={token.ResetToken}";
+                             $"{ServerConfiguration.Instance.ExternalUrl}/passwordReset?token={token.ResetToken}\n\n" + 
+                             "This link will expire in one hour";
 
         await mail.SendEmailAsync(user.EmailAddress, $"Project Lighthouse Password Reset Request for {user.Username}", messageBody);
 


### PR DESCRIPTION
This PR adds an expiration for password reset tokens (they used to live forever apparently) and also prevents someone from generating a new password reset request unless the old one has been removed either manually or after the automated 24h period.