### PR TITLE
Sort team picks by the time they were team picked

### DIFF
--- a/ProjectLighthouse.Servers.API/Responses/ApiSlot.cs
+++ b/ProjectLighthouse.Servers.API/Responses/ApiSlot.cs
@@ -61,7 +61,7 @@ public struct ApiSlot
             MoveRequired = slot.MoveRequired,
             FirstUploaded = slot.FirstUploaded,
             LastUpdated = slot.LastUpdated,
-            TeamPick = slot.TeamPick,
+            TeamPick = slot.TeamPickTime != 0,
             Location = slot.Location,
             GameVersion = slot.GameVersion,
             Plays = slot.Plays,

--- a/ProjectLighthouse.Servers.API/Responses/MinimalApiSlot.cs
+++ b/ProjectLighthouse.Servers.API/Responses/MinimalApiSlot.cs
@@ -31,7 +31,7 @@ public struct MinimalApiSlot
             Type = slot.Type,
             Name = slot.Name,
             IconHash = slot.IconHash,
-            TeamPick = slot.TeamPick,
+            TeamPick = slot.TeamPickTime != 0,
             IsAdventure = slot.IsAdventurePlanet,
             Location = slot.Location,
             GameVersion = slot.GameVersion,

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -247,7 +247,8 @@ public class SlotsController : ControllerBase
         pageData.TotalElements = await StatisticsHelper.SlotCount(this.database, queryBuilder);
 
         SlotSortBuilder<SlotEntity> sortBuilder = new();
-        sortBuilder.AddSort(new LastUpdatedSort());
+        sortBuilder.AddSort(new TeamPickSort());
+        sortBuilder.AddSort(new FirstUploadedSort());
 
         List<SlotBase> slots = await this.database.GetSlots(token, queryBuilder, pageData, sortBuilder);
 

--- a/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/Categories/TeamPicksCategory.cs
@@ -19,5 +19,5 @@ public class TeamPicksCategory : SlotCategory
 
     public override IQueryable<SlotEntity> GetItems(DatabaseContext database, GameTokenEntity token, SlotQueryBuilder queryBuilder) =>
         database.Slots.Where(queryBuilder.Clone().AddFilter(new TeamPickFilter()).Build())
-            .ApplyOrdering(new SlotSortBuilder<SlotEntity>().AddSort(new FirstUploadedSort()));
+            .ApplyOrdering(new SlotSortBuilder<SlotEntity>().AddSort(new TeamPickSort()).AddSort(new FirstUploadedSort()));
 }

--- a/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Moderator/ModerationSlotController.cs
@@ -28,7 +28,7 @@ public class ModerationSlotController : ControllerBase
         SlotEntity? slot = await this.database.Slots.Include(s => s.Creator).FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.NotFound();
 
-        slot.TeamPick = true;
+        slot.TeamPickTime = TimeHelper.TimestampMillis;
 
         // Send webhook with slot.Name and slot.Creator.Username
         await WebhookHelper.SendWebhook("New Team Pick!", $"The level [**{slot.Name}**]({ServerConfiguration.Instance.ExternalUrl}/slot/{slot.SlotId}) by **{slot.Creator?.Username}** has been team picked");
@@ -51,7 +51,7 @@ public class ModerationSlotController : ControllerBase
         SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.NotFound();
 
-        slot.TeamPick = false;
+        slot.TeamPickTime = 0;
 
         // Send a notification to the creator
         await this.database.SendNotification(slot.CreatorId,

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml.cs
@@ -41,8 +41,9 @@ public class LandingPage : BaseLayout
         const int maxShownLevels = 5;
 
         this.LatestTeamPicks = await this.Database.Slots.Where(s => s.Type == SlotType.User && !s.SubLevel && !s.Hidden)
-            .Where(s => s.TeamPick)
-            .OrderByDescending(s => s.FirstUploaded)
+            .Where(s => s.TeamPickTime != 0)
+            .OrderByDescending(s => s.TeamPickTime)
+            .ThenByDescending(s => s.FirstUploaded)
             .Take(maxShownLevels)
             .Include(s => s.Creator)
             .ToListAsync();

--- a/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotPage.cshtml
@@ -217,9 +217,9 @@ else
     <div class="ui green segment">
         <h2>Moderation Options</h2>
 
-        @if (Model.Slot?.TeamPick ?? false)
+        @if ((Model.Slot?.TeamPickTime ?? 0) != 0)
         {
-            <a href="/moderation/slot/@Model.Slot.SlotId/removeTeamPick">
+            <a href="/moderation/slot/@Model.Slot?.SlotId/removeTeamPick">
                 <div class="ui pink button">
                     <i class="star icon"></i>
                     <span>Remove Team Pick</span>

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/StatisticsControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/StatisticsControllerTests.cs
@@ -51,7 +51,7 @@ public class StatisticsControllerTests
             {
                 SlotId = 3,
                 CreatorId = 1,
-                TeamPick = true,
+                TeamPickTime = 1,
             },
         };
         await using DatabaseContext db = await MockHelper.GetTestDatabase(slots);
@@ -90,7 +90,7 @@ public class StatisticsControllerTests
             {
                 SlotId = 3,
                 CreatorId = 1,
-                TeamPick = true,
+                TeamPickTime = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
         };
@@ -130,7 +130,7 @@ public class StatisticsControllerTests
             {
                 SlotId = 3,
                 CreatorId = 1,
-                TeamPick = true,
+                TeamPickTime = 1,
                 GameVersion = GameVersion.LittleBigPlanet1,
             },
         };
@@ -168,7 +168,7 @@ public class StatisticsControllerTests
             {
                 SlotId = 3,
                 CreatorId = 1,
-                TeamPick = true,
+                TeamPickTime = 1,
                 GameVersion = GameVersion.LittleBigPlanet2,
             },
         }; 

--- a/ProjectLighthouse.Tests/Unit/FilterTests.cs
+++ b/ProjectLighthouse.Tests/Unit/FilterTests.cs
@@ -729,7 +729,7 @@ public class FilterTests
 
         SlotEntity slot = new()
         {
-            TeamPick = true,
+            TeamPickTime = 1,
         };
 
         Assert.True(teamPickFunc(slot));
@@ -743,7 +743,7 @@ public class FilterTests
 
         SlotEntity slot = new()
         {
-            TeamPick = false,
+            TeamPickTime = 0,
         };
 
         Assert.False(teamPickFunc(slot));

--- a/ProjectLighthouse/Filter/Filters/TeamPickFilter.cs
+++ b/ProjectLighthouse/Filter/Filters/TeamPickFilter.cs
@@ -7,5 +7,5 @@ namespace LBPUnion.ProjectLighthouse.Filter.Filters;
 
 public class TeamPickFilter : ISlotFilter
 {
-    public Expression<Func<SlotEntity, bool>> GetPredicate() => s => s.TeamPick;
+    public Expression<Func<SlotEntity, bool>> GetPredicate() => s => s.TeamPickTime != 0;
 }

--- a/ProjectLighthouse/Filter/Sorts/TeamPickSort.cs
+++ b/ProjectLighthouse/Filter/Sorts/TeamPickSort.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq.Expressions;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using LBPUnion.ProjectLighthouse.Types.Filter.Sorts;
+
+namespace LBPUnion.ProjectLighthouse.Filter.Sorts;
+
+public class TeamPickSort : ISlotSort
+{
+    public Expression<Func<SlotEntity, dynamic>> GetExpression() => s => s.TeamPickTime;
+}

--- a/ProjectLighthouse/Migrations/20240214031744_UpdateTeamPickBoolToTimestamp.cs
+++ b/ProjectLighthouse/Migrations/20240214031744_UpdateTeamPickBoolToTimestamp.cs
@@ -1,0 +1,44 @@
+﻿using LBPUnion.ProjectLighthouse.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ProjectLighthouse.Migrations
+{
+    [DbContext(typeof(DatabaseContext))]
+    [Migration("20240214031744_UpdateTeamPickBoolToTimestamp")]
+    public partial class UpdateTeamPickBoolToTimestamp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(name: "TeamPickTime",
+                table: "Slots",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.Sql("UPDATE `Slots` SET TeamPickTime = 1 WHERE TeamPick = 1");
+
+            migrationBuilder.DropColumn(
+                name: "TeamPick",
+                table: "Slots");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TeamPickTime",
+                table: "Slots");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TeamPick",
+                table: "Slots",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/ProjectLighthouse/Migrations/DatabaseContextModelSnapshot.cs
+++ b/ProjectLighthouse/Migrations/DatabaseContextModelSnapshot.cs
@@ -472,8 +472,8 @@ namespace ProjectLighthouse.Migrations
                     b.Property<bool>("SubLevel")
                         .HasColumnType("tinyint(1)");
 
-                    b.Property<bool>("TeamPick")
-                        .HasColumnType("tinyint(1)");
+                    b.Property<long>("TeamPickTime")
+                        .HasColumnType("bigint");
 
                     b.Property<int>("Type")
                         .HasColumnType("int");

--- a/ProjectLighthouse/Types/Entities/Level/SlotEntity.cs
+++ b/ProjectLighthouse/Types/Entities/Level/SlotEntity.cs
@@ -102,7 +102,7 @@ public class SlotEntity
 
     public long LastUpdated { get; set; }
 
-    public bool TeamPick { get; set; }
+    public long TeamPickTime { get; set; }
 
     public GameVersion GameVersion { get; set; }
 

--- a/ProjectLighthouse/Types/Serialization/SlotBase.cs
+++ b/ProjectLighthouse/Types/Serialization/SlotBase.cs
@@ -84,7 +84,7 @@ public abstract class SlotBase : ILbpSerializable
             InitiallyLocked = slot.InitiallyLocked,
             RootLevel = slot.RootLevel,
             IsShareable = slot.Shareable,
-            IsTeamPicked = slot.TeamPick,
+            IsTeamPicked = slot.TeamPickTime != 0,
             FirstUploaded = slot.FirstUploaded,
             LastUpdated = slot.LastUpdated,
             IsCrossControlRequired = slot.CrossControllerRequired,


### PR DESCRIPTION
 Instead of sorting team picks by the time the level was last updated or uploaded, we can store when the level was picked and sort by that instead. On migration, already team-picked levels are set to a timestamp of 1 so they will still count as team-picked but will all show up last.