### PR TITLE
Rewrite digest middleware

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
@@ -1,9 +1,9 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Filter;
@@ -11,17 +11,12 @@ using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class CommentController : ControllerBase
+public class CommentController : GameController
 {
     private readonly DatabaseContext database;
     public CommentController(DatabaseContext database)

--- a/ProjectLighthouse.Servers.GameServer/Controllers/DeveloperController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/DeveloperController.cs
@@ -1,14 +1,10 @@
-﻿using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
+﻿using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
+using LBPUnion.ProjectLighthouse.Types.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class DeveloperController : Controller
+public class DeveloperController : GameController
 {
     [HttpGet("developer_videos")]
     public IActionResult DeveloperVideos() => this.Ok(new GameDeveloperVideos());

--- a/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/FriendsController.cs
@@ -1,23 +1,18 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Users;
 using LBPUnion.ProjectLighthouse.StorableLists.Stores;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class FriendsController : ControllerBase
+public class FriendsController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/ClientConfigurationController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/ClientConfigurationController.cs
@@ -1,22 +1,18 @@
-#nullable enable
 using System.Diagnostics.CodeAnalysis;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Users;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Login;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
 [Produces("text/plain")]
-public class ClientConfigurationController : ControllerBase
+public class ClientConfigurationController : GameController
 {
     private readonly DatabaseContext database;
 
@@ -26,6 +22,7 @@ public class ClientConfigurationController : ControllerBase
     }
 
     [HttpGet("network_settings.nws")]
+    [UseDigest(EnforceDigest = false)]
     [SuppressMessage("ReSharper", "StringLiteralTypo")]
     public IActionResult NetworkSettings()
     {
@@ -41,15 +38,18 @@ public class ClientConfigurationController : ControllerBase
 
     [HttpGet("t_conf")]
     [Produces("text/xml")]
+    [UseDigest(EnforceDigest = false)]
     public IActionResult Conf() => this.Ok(new TelemetryConfigResponse());
 
     // The challenge config here is currently based on the official server's config.
     // We should probably make this configurable in the future.
     [HttpGet("ChallengeConfig.xml")]
     [Produces("text/xml")]
+    [UseDigest(EnforceDigest = false)]
     public IActionResult Challenges() => this.Ok(GameChallengeResponse.ServerChallenges());
 
     [HttpGet("farc_hashes")]
+    [UseDigest(EnforceDigest = false)]
     public IActionResult FarcHashes() => this.Ok();
 
     [HttpGet("privacySettings")]

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/LogoutController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/LogoutController.cs
@@ -1,20 +1,15 @@
 ﻿using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Login;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/goodbye")]
-[Produces("text/xml")]
-public class LogoutController : ControllerBase
+public class LogoutController : GameController
 {
-
     private readonly DatabaseContext database;
 
     public LogoutController(DatabaseContext database)
@@ -22,8 +17,8 @@ public class LogoutController : ControllerBase
         this.database = database;
     }
 
-    [HttpPost]
-    public async Task<IActionResult> OnPost()
+    [HttpPost("goodbye")]
+    public async Task<IActionResult> OnLogout()
     {
         GameTokenEntity token = this.GetToken();
 
@@ -37,6 +32,4 @@ public class LogoutController : ControllerBase
 
         return this.Ok();
     }
-
-    
 }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Matching/EnterLevelController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Matching/EnterLevelController.cs
@@ -1,22 +1,17 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Matching;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class EnterLevelController : ControllerBase
+public class EnterLevelController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Matching/MatchController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Matching/MatchController.cs
@@ -1,26 +1,21 @@
-#nullable enable
 using System.Text.Json;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Matchmaking;
 using LBPUnion.ProjectLighthouse.Types.Matchmaking.MatchCommands;
 using LBPUnion.ProjectLighthouse.Types.Matchmaking.Rooms;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Matching;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class MatchController : ControllerBase
+public class MatchController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -5,23 +5,20 @@ using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Serialization;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Notifications;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Mail;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
 [Produces("text/plain")]
-public class MessageController : ControllerBase
+public class MessageController : GameController
 {
     private readonly DatabaseContext database;
 
@@ -45,9 +42,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
     }
 
     [HttpGet("eula")]
+    [UseDigest(EnforceDigest = false)]
     public IActionResult Eula() => this.Ok($"{license}\n{ServerConfiguration.Instance.EulaText}");
 
     [HttpGet("announce")]
+    [UseDigest(EnforceDigest = false)]
     public async Task<IActionResult> Announce()
     {
         GameTokenEntity token = this.GetToken();

--- a/ProjectLighthouse.Servers.GameServer/Controllers/ReportController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/ReportController.cs
@@ -1,24 +1,19 @@
-﻿#nullable enable
-using System.Text.Json;
+﻿using System.Text.Json;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Moderation;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Moderation.Reports;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class ReportController : ControllerBase
+public class ReportController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Discord;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
@@ -6,6 +5,7 @@ using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -13,17 +13,12 @@ using LBPUnion.ProjectLighthouse.Types.Filter;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Resources;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class PhotosController : ControllerBase
+public class PhotosController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
@@ -1,22 +1,17 @@
-#nullable enable
 using System.Text;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Resources;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using IOFile = System.IO.File;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Resources;
 
-[ApiController]
-[Authorize]
-[Produces("text/xml")]
-[Route("LITTLEBIGPLANETPS3_XML")]
-public class ResourcesController : ControllerBase
+public class ResourcesController : GameController
 {
 
     [HttpPost("showModerated")]
@@ -51,6 +46,7 @@ public class ResourcesController : ControllerBase
 
     [HttpPost("upload/{hash}/unattributed")]
     [HttpPost("upload/{hash}")]
+    [UseDigest(DigestHeaderName = "X-Digest-B", ExcludeBodyFromDigest = true)]
     public async Task<IActionResult> UploadResource(string hash)
     {
         string assetsDirectory = FileHelper.ResourcePath;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/CategoryController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/CategoryController.cs
@@ -4,6 +4,7 @@ using LBPUnion.ProjectLighthouse.Filter;
 using LBPUnion.ProjectLighthouse.Filter.Sorts;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Categories;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
@@ -13,17 +14,12 @@ using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class CategoryController : ControllerBase
+public class CategoryController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/LevelTagsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/LevelTagsController.cs
@@ -1,22 +1,18 @@
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML")]
-[Produces("text/plain")]
-public class LevelTagsController : ControllerBase
+public class LevelTagsController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ListController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ListController.cs
@@ -1,9 +1,9 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Filter;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -11,17 +11,12 @@ using LBPUnion.ProjectLighthouse.Types.Filter;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class ListController : ControllerBase
+public class ListController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PlaylistController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PlaylistController.cs
@@ -1,21 +1,16 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class PlaylistController : ControllerBase
+public class PlaylistController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -6,6 +6,7 @@ using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -23,7 +24,7 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 [Authorize]
 [Route("LITTLEBIGPLANETPS3_XML/")]
 [Produces("text/xml")]
-public class PublishController : ControllerBase
+public class PublishController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ReviewController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ReviewController.cs
@@ -1,23 +1,18 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Interaction;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Filter;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class ReviewController : ControllerBase
+public class ReviewController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ScoreController.cs
@@ -1,8 +1,8 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Logging;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.StorableLists.Stores;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
@@ -10,17 +10,12 @@ using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class ScoreController : ControllerBase
+public class ScoreController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SearchController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SearchController.cs
@@ -1,25 +1,20 @@
-#nullable enable
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Filter;
 using LBPUnion.ProjectLighthouse.Filter.Filters;
 using LBPUnion.ProjectLighthouse.Filter.Sorts;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Filter;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/slots")]
-[Produces("text/xml")]
-public class SearchController : ControllerBase
+public class SearchController : GameController
 {
     private readonly DatabaseContext database;
     public SearchController(DatabaseContext database)

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/SlotsController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Linq.Expressions;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
@@ -8,6 +7,7 @@ using LBPUnion.ProjectLighthouse.Filter.Sorts;
 using LBPUnion.ProjectLighthouse.Filter.Sorts.Metadata;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Token;
 using LBPUnion.ProjectLighthouse.Types.Filter;
@@ -15,17 +15,12 @@ using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Misc;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class SlotsController : ControllerBase
+public class SlotsController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
@@ -1,20 +1,17 @@
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Helpers;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Filter;
 using LBPUnion.ProjectLighthouse.Filter.Filters;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Extensions;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
 [Produces("text/plain")]
-public class StatisticsController : ControllerBase
+public class StatisticsController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StoreController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StoreController.cs
@@ -1,13 +1,9 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class StoreController : Controller
+public class StoreController : GameController
 {
     [HttpGet("promotions")]
     public IActionResult Promotions() => this.Ok();

--- a/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
@@ -4,6 +4,7 @@ using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Helpers;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using LBPUnion.ProjectLighthouse.Servers.GameServer.Types.Users;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
@@ -12,17 +13,12 @@ using LBPUnion.ProjectLighthouse.Types.Levels;
 using LBPUnion.ProjectLighthouse.Types.Logging;
 using LBPUnion.ProjectLighthouse.Types.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Users;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers;
 
-[ApiController]
-[Authorize]
-[Route("LITTLEBIGPLANETPS3_XML/")]
-[Produces("text/xml")]
-public class UserController : ControllerBase
+public class UserController : GameController
 {
     private readonly DatabaseContext database;
 

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
@@ -2,6 +2,7 @@ using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Middlewares;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
 using Microsoft.Extensions.Primitives;
 using Org.BouncyCastle.Utilities.Zlib;
 
@@ -16,101 +17,17 @@ public class DigestMiddleware : Middleware
         this.computeDigests = computeDigests;
     }
 
-    #if !DEBUG
-    private static readonly HashSet<string> exemptPathList = new()
+    private readonly List<string> digestKeys;
+
+    public DigestMiddleware(RequestDelegate next, List<string> digestKeys) : base(next)
     {
-        "/login",
-        "/eula",
-        "/announce",
-        "/status",
-        "/farc_hashes",
-        "/t_conf",
-        "/network_settings.nws",
-        "/ChallengeConfig.xml",
-    };
-    #endif
+        this.digestKeys = digestKeys;
+    }
 
-    public override async Task InvokeAsync(HttpContext context)
+    private static async Task HandleResponseCompression(HttpContext context, MemoryStream responseBuffer)
     {
-        // Client digest check.
-        if (!context.Request.Cookies.TryGetValue("MM_AUTH", out string? authCookie)) authCookie = string.Empty;
-        string digestPath = context.Request.Path;
-        #if !DEBUG
-        const string url = "/LITTLEBIGPLANETPS3_XML";
-        string strippedPath = digestPath.Contains(url) ? digestPath[url.Length..] : "";
-        #endif
-        byte[] bodyBytes = await context.Request.BodyReader.ReadAllAsync();
-
-        bool usedAlternateDigestKey = false;
-
-        if (this.computeDigests && digestPath.StartsWith("/LITTLEBIGPLANETPS3_XML"))
-        {
-            // The game sets X-Digest-B on a resource upload instead of X-Digest-A
-            string digestHeaderKey = "X-Digest-A";
-            bool excludeBodyFromDigest = false;
-            if (digestPath.Contains("/upload/"))
-            {
-                digestHeaderKey = "X-Digest-B";
-                excludeBodyFromDigest = true;
-            }
-
-            string clientRequestDigest = CryptoHelper.ComputeDigest(digestPath,
-                authCookie,
-                bodyBytes,
-                ServerConfiguration.Instance.DigestKey.PrimaryDigestKey,
-                excludeBodyFromDigest);
-
-            // Check the digest we've just calculated against the digest header if the game set the header. They should match.
-            if (context.Request.Headers.TryGetValue(digestHeaderKey, out StringValues sentDigest))
-            {
-                if (clientRequestDigest != sentDigest)
-                {
-                    // If we got here, the normal ServerDigestKey failed to validate. Lets try again with the alternate digest key.
-                    usedAlternateDigestKey = true;
-
-                    clientRequestDigest = CryptoHelper.ComputeDigest(digestPath,
-                        authCookie,
-                        bodyBytes,
-                        ServerConfiguration.Instance.DigestKey.AlternateDigestKey,
-                        excludeBodyFromDigest);
-                    if (clientRequestDigest != sentDigest)
-                    {
-                        #if DEBUG
-                        Console.WriteLine("Digest failed");
-                        Console.WriteLine("digestKey: " + ServerConfiguration.Instance.DigestKey.PrimaryDigestKey);
-                        Console.WriteLine("altDigestKey: " + ServerConfiguration.Instance.DigestKey.AlternateDigestKey);
-                        Console.WriteLine("computed digest: " + clientRequestDigest);
-                        #endif
-                        // We still failed to validate. Abort the request.
-                        context.Response.StatusCode = 403;
-                        return;
-                    }
-                }
-            }
-
-            #if !DEBUG
-            // The game doesn't start sending digests until after the announcement so if it's not one of those requests
-            // and it doesn't include a digest we need to reject the request
-            else if (!exemptPathList.Contains(strippedPath))
-            {
-                context.Response.StatusCode = 403;
-                return;
-            }
-            #endif
-
-            context.Response.Headers.Append("X-Digest-B", clientRequestDigest);
-            context.Request.Body.Position = 0;
-        }
-
-        // This does the same as above, but for the response stream.
-        await using MemoryStream responseBuffer = new();
-        Stream oldResponseStream = context.Response.Body;
-        context.Response.Body = responseBuffer;
-
-        await this.next(context); // Handle the request so we can get the server digest hash
-        responseBuffer.Position = 0;
-
-        if (responseBuffer.Length > 1000 &&
+        const int minCompressionLen = 1000;
+        if (responseBuffer.Length > minCompressionLen &&
             context.Request.Headers.AcceptEncoding.Contains("deflate") &&
             (context.Response.ContentType ?? string.Empty).Contains("text/xml"))
         {
@@ -130,30 +47,94 @@ public class DigestMiddleware : Middleware
         }
         else
         {
-            string headerName = !context.Response.Headers.ContentLength.HasValue
-                ? "Content-Length"
-                : "X-Original-Content-Length";
+            string headerName = !context.Response.Headers.ContentLength.HasValue ? "Content-Length" : "X-Original-Content-Length";
             context.Response.Headers.Append(headerName, responseBuffer.Length.ToString());
         }
+    }
 
-        // Compute the server digest hash.
-        if (this.computeDigests)
+    public override async Task InvokeAsync(HttpContext context)
+    {
+        UseDigestAttribute? digestAttribute = context.GetEndpoint()?.Metadata.OfType<UseDigestAttribute>().FirstOrDefault();
+        if (digestAttribute == null)
         {
-            responseBuffer.Position = 0;
-
-            string digestKey = usedAlternateDigestKey
-                ? ServerConfiguration.Instance.DigestKey.AlternateDigestKey
-                : ServerConfiguration.Instance.DigestKey.PrimaryDigestKey;
-
-            // Compute the digest for the response.
-            string serverDigest =
-                CryptoHelper.ComputeDigest(context.Request.Path, authCookie, responseBuffer.ToArray(), digestKey);
-            context.Response.Headers.Append("X-Digest-A", serverDigest);
+            await this.next(context);
+            return;
         }
 
-        // Copy the buffered response to the actual response stream.
+        if (!context.Request.Cookies.TryGetValue("MM_AUTH", out string? authCookie))
+        {
+            context.Response.StatusCode = 403;
+            return;
+        }
+
+        string digestPath = context.Request.Path;
+
+        byte[] bodyBytes = await context.Request.BodyReader.ReadAllAsync();
+
+        if (!context.Request.Headers.TryGetValue(digestAttribute.DigestHeaderName, out StringValues digestHeaders) ||
+            digestHeaders.Count != 1 && digestAttribute.EnforceDigest)
+        {
+            context.Response.StatusCode = 403;
+            return;
+        }
+
+        string? clientDigest = digestHeaders[0];
+
+        string? matchingDigestKey = null;
+        string? calculatedRequestDigest = null;
+
+        foreach (string digestKey in this.digestKeys)
+        {
+            string calculatedDigest = CryptoHelper.ComputeDigest(digestPath,
+                authCookie,
+                bodyBytes,
+                digestKey,
+                digestAttribute.ExcludeBodyFromDigest);
+            if (calculatedDigest != clientDigest) continue;
+
+            matchingDigestKey = digestKey;
+            calculatedRequestDigest = calculatedDigest;
+        }
+
+        matchingDigestKey ??= this.digestKeys.First();
+
+        switch (matchingDigestKey)
+        {
+            case null when digestAttribute.EnforceDigest:
+                context.Response.StatusCode = 403;
+                return;
+            case null:
+                calculatedRequestDigest = CryptoHelper.ComputeDigest(digestPath,
+                    authCookie,
+                    bodyBytes,
+                    matchingDigestKey,
+                    digestAttribute.ExcludeBodyFromDigest);
+                break;
+        }
+
+        context.Response.Headers.Append("X-Digest-B", calculatedRequestDigest);
+        // context.Request.Body.Position = 0;
+
+        // Let endpoint generate response so we can calculate the digest for it
+        Stream originalBody = context.Response.Body;
+        await using MemoryStream responseBuffer = new();
+        context.Response.Body = responseBuffer;
+
+        await this.next(context);
+
+        await HandleResponseCompression(context, responseBuffer);
+
+        string responseDigest = CryptoHelper.ComputeDigest(digestPath,
+            authCookie,
+            responseBuffer.ToArray(),
+            matchingDigestKey,
+            digestAttribute.ExcludeBodyFromDigest);
+
+        context.Response.Headers.Append("X-Digest-A", responseDigest);
+
         responseBuffer.Position = 0;
-        await responseBuffer.CopyToAsync(oldResponseStream);
-        context.Response.Body = oldResponseStream;
+        await responseBuffer.CopyToAsync(originalBody);
+        context.Response.Body = originalBody;
     }
+
 }

--- a/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
+++ b/ProjectLighthouse.Servers.GameServer/Middlewares/DigestMiddleware.cs
@@ -103,7 +103,6 @@ public class DigestMiddleware : Middleware
         }
 
         context.Response.Headers.Append("X-Digest-B", calculatedRequestDigest);
-        // context.Request.Body.Position = 0;
 
         // Let endpoint generate response so we can calculate the digest for it
         Stream originalBody = context.Response.Body;

--- a/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
+++ b/ProjectLighthouse.Servers.GameServer/Startup/GameServerStartup.cs
@@ -84,8 +84,6 @@ public class GameServerStartup
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        bool computeDigests = true;
-
         if (string.IsNullOrEmpty(ServerConfiguration.Instance.DigestKey.PrimaryDigestKey))
         {
             Logger.Warn
@@ -94,7 +92,6 @@ public class GameServerStartup
                 "To increase security, it is recommended that you find and set this variable.",
                 LogArea.Startup
             );
-            computeDigests = false;
         }
 
         #if DEBUG
@@ -105,10 +102,16 @@ public class GameServerStartup
 
         app.UseMiddleware<RequestLogMiddleware>();
         app.UseMiddleware<RateLimitMiddleware>();
-        app.UseMiddleware<DigestMiddleware>(computeDigests);
         app.UseMiddleware<SetLastContactMiddleware>();
 
         app.UseRouting();
+
+        List<string> digestKeys =
+        [
+            ServerConfiguration.Instance.DigestKey.PrimaryDigestKey,
+            ServerConfiguration.Instance.DigestKey.AlternateDigestKey,
+        ];
+        app.UseMiddleware<DigestMiddleware>(digestKeys);
 
         app.UseAuthorization();
 

--- a/ProjectLighthouse.Servers.GameServer/Types/GameController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/GameController.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
+
+[ApiController]
+[Authorize]
+[UseDigest]
+[Route("LITTLEBIGPLANETPS3_XML/")]
+[Produces("text/xml")]
+public class GameController : ControllerBase;

--- a/ProjectLighthouse.Servers.GameServer/Types/UseDigestAttribute.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/UseDigestAttribute.cs
@@ -7,5 +7,5 @@ public class UseDigestAttribute : Attribute
 
     public string DigestHeaderName { get; set; } = "X-Digest-A";
 
-    public bool ExcludeBodyFromDigest { get; set; } = false;
+    public bool ExcludeBodyFromDigest { get; set; }
 }

--- a/ProjectLighthouse.Servers.GameServer/Types/UseDigestAttribute.cs
+++ b/ProjectLighthouse.Servers.GameServer/Types/UseDigestAttribute.cs
@@ -1,0 +1,11 @@
+namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Types;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+public class UseDigestAttribute : Attribute
+{
+    public bool EnforceDigest { get; set; } = true;
+
+    public string DigestHeaderName { get; set; } = "X-Digest-A";
+
+    public bool ExcludeBodyFromDigest { get; set; } = false;
+}


### PR DESCRIPTION
This PR is a refactor of the digest middleware. The new version makes it much less dependent on hardcoded endpoints and the digests in the config. Now the hardcoded behavior can be controlled by changing properties in the `UseDigestAttribute` class, like whether or not the request should fail if the client sends an incorrect digest or what the digest header name should be. The middleware can now also use unlimited digest keys to check against. 

This PR also adds a new GameController class which extracts most of the common attributes the LBP endpoints use so they don't have to be redefined in every file.