### PR TITLE
Implement read-only mode

### DIFF
--- a/ProjectLighthouse.Localization/BaseLayout.resx
+++ b/ProjectLighthouse.Localization/BaseLayout.resx
@@ -87,4 +87,10 @@
     <data name="license_warn_3" xml:space="preserve">
         <value>If not, please publish the source code somewhere accessible to your users.</value>
     </data>
+    <data name="read_only_warn_title" xml:space="preserve">
+        <value>Read-Only Mode</value>
+    </data>
+    <data name="read_only_warn" xml:space="preserve">
+        <value>This instance is currently in read-only mode. Level and photo uploads, comments, reviews, and certain profile changes will be restricted until read-only mode is disabled.</value>
+    </data>
 </root>

--- a/ProjectLighthouse.Localization/StringLists/BaseLayoutStrings.cs
+++ b/ProjectLighthouse.Localization/StringLists/BaseLayoutStrings.cs
@@ -23,5 +23,8 @@ public static class BaseLayoutStrings
     public static readonly TranslatableString LicenseWarn2 = create("license_warn_2");
     public static readonly TranslatableString LicenseWarn3 = create("license_warn_3");
 
+    public static readonly TranslatableString ReadOnlyWarnTitle = create("read_only_warn_title");
+    public static readonly TranslatableString ReadOnlyWarn = create("read_only_warn");
+
     private static TranslatableString create(string key) => new(TranslationAreas.BaseLayout, key);
 }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/CommentController.cs
@@ -119,6 +119,9 @@ public class CommentController : ControllerBase
     {
         GameTokenEntity token = this.GetToken();
 
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
         GameComment? comment = await this.DeserializeBody<GameComment>();
         if (comment?.Message == null) return this.BadRequest();
 
@@ -158,6 +161,9 @@ public class CommentController : ControllerBase
     public async Task<IActionResult> DeleteComment([FromQuery] int commentId, string? username, string? slotType, int slotId)
     {
         GameTokenEntity token = this.GetToken();
+
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
 
         if ((slotId == 0 || SlotHelper.IsTypeInvalid(slotType)) == (username == null)) return this.BadRequest();
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -59,6 +59,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
         announceText.Replace("%user", username);
         announceText.Replace("%id", token.UserId.ToString());
 
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+        {
+            announceText.Insert(0, "This instance is currently in read-only mode. Level and photo uploads, comments, " +
+                                   "reviews, and certain profile changes will be restricted until read-only mode is " +
+                                   "disabled.");
+        }
+
         #if DEBUG
         announceText.Append("\n\n---DEBUG INFO---\n" +
                                   $"user.UserId: {token.UserId}\n" +

--- a/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/MessageController.cs
@@ -3,6 +3,8 @@ using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Helpers;
+using LBPUnion.ProjectLighthouse.Localization;
+using LBPUnion.ProjectLighthouse.Localization.StringLists;
 using LBPUnion.ProjectLighthouse.Logging;
 using LBPUnion.ProjectLighthouse.Serialization;
 using LBPUnion.ProjectLighthouse.Types.Entities.Notifications;
@@ -61,9 +63,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.";
 
         if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
         {
-            announceText.Insert(0, "This instance is currently in read-only mode. Level and photo uploads, comments, " +
-                                   "reviews, and certain profile changes will be restricted until read-only mode is " +
-                                   "disabled.");
+            announceText.Insert(0, BaseLayoutStrings.ReadOnlyWarn.Translate(LocalizationManager.DefaultLang));
         }
 
         #if DEBUG

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/PhotosController.cs
@@ -37,6 +37,9 @@ public class PhotosController : ControllerBase
     {
         GameTokenEntity token = this.GetToken();
 
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
         int photoCount = await this.database.Photos.CountAsync(p => p.CreatorId == token.UserId);
         if (photoCount >= ServerConfiguration.Instance.UserGeneratedContentLimits.PhotosQuota) return this.BadRequest();
 
@@ -90,7 +93,7 @@ public class PhotosController : ControllerBase
                 case SlotType.Developer:
                 {
                     SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.Type == photoSlot.SlotType && s.InternalSlotId == photoSlot.SlotId);
-                    if (slot != null) 
+                    if (slot != null)
                         photoSlot.SlotId = slot.SlotId;
                     else
                         photoSlot.SlotId = await SlotHelper.GetPlaceholderSlotId(this.database, photoSlot.SlotId, photoSlot.SlotType);

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Resources/ResourcesController.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Text;
+using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Logging;
@@ -58,10 +59,14 @@ public class ResourcesController : ControllerBase
         string fullPath = Path.GetFullPath(path);
 
         FileHelper.EnsureDirectoryCreated(assetsDirectory);
-        // lbp treats code 409 as success and as an indicator that the file is already present
+
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
+        // LBP treats code 409 as success and as an indicator that the file is already present
         if (FileHelper.ResourceExists(hash)) return this.Conflict();
 
-        // theoretically shouldn't be possible because of hash check but handle anyways
+        // Theoretically shouldn't be possible because of hash check but handle anyways
         if (!fullPath.StartsWith(FileHelper.FullResourcePath)) return this.BadRequest();
 
         Logger.Info($"Processing resource upload (hash: {hash})", LogArea.Resources);

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/PublishController.cs
@@ -43,6 +43,9 @@ public class PublishController : ControllerBase
         UserEntity? user = await this.database.UserFromGameToken(token);
         if (user == null) return this.Forbid();
 
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
         GameUserSlot? slot = await this.DeserializeBody<GameUserSlot>();
         if (slot == null)
         {
@@ -115,6 +118,9 @@ public class PublishController : ControllerBase
 
         UserEntity? user = await this.database.UserFromGameToken(token);
         if (user == null) return this.Forbid();
+
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
 
         GameUserSlot? slot = await this.DeserializeBody<GameUserSlot>();
 
@@ -334,6 +340,9 @@ public class PublishController : ControllerBase
     public async Task<IActionResult> Unpublish(int id)
     {
         GameTokenEntity token = this.GetToken();
+
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
 
         SlotEntity? slot = await this.database.Slots.FirstOrDefaultAsync(s => s.SlotId == id);
         if (slot == null) return this.NotFound();

--- a/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Extensions;
 using LBPUnion.ProjectLighthouse.Files;
@@ -73,6 +74,9 @@ public class UserController : ControllerBase
 
         if (update.Biography != null)
         {
+            // Deny request if in read-only mode
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
             if (update.Biography.Length > 512) return this.BadRequest();
 
             user.Biography = update.Biography;
@@ -84,6 +88,9 @@ public class UserController : ControllerBase
         foreach (string? resource in new[]{update.IconHash, update.YayHash, update.MehHash, update.BooHash,})
         {
             if (string.IsNullOrWhiteSpace(resource)) continue;
+
+            // Deny request if in read-only mode
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
 
             if (!FileHelper.ResourceExists(resource) && !resource.StartsWith('g')) return this.BadRequest();
 

--- a/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
@@ -10,7 +10,7 @@ using LBPUnion.ProjectLighthouse.Types.Logging;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
-// I would like to apologize in advance for anyone dealing with this file. 
+// I would like to apologize in advance for anyone dealing with this file.
 // Theres probably a better way to do this with delegates but I'm tired.
 // TODO: Clean up this file
 // - jvyden
@@ -62,6 +62,9 @@ public class SlotPageController : ControllerBase
     {
         WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
         if (token == null) return this.Redirect("~/login");
+
+    // Deny request if in read-only mode
+    if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect("~/slot/" + id);
 
         if (msg == null)
         {

--- a/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/SlotPageController.cs
@@ -63,8 +63,8 @@ public class SlotPageController : ControllerBase
         WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
         if (token == null) return this.Redirect("~/login");
 
-    // Deny request if in read-only mode
-    if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect("~/slot/" + id);
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect("~/slot/" + id);
 
         if (msg == null)
         {

--- a/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
@@ -40,7 +40,7 @@ public class UserPageController : ControllerBase
         if (token == null) return this.Redirect("~/login");
 
         // Deny request if in read-only mode
-        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect("~/user/" + id);
 
         if (msg == null)
         {

--- a/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/UserPageController.cs
@@ -39,6 +39,9 @@ public class UserPageController : ControllerBase
         WebTokenEntity? token = this.database.WebTokenFromRequest(this.Request);
         if (token == null) return this.Redirect("~/login");
 
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
         if (msg == null)
         {
             Logger.Error($"Refusing to post comment from {token.UserId} on user {id}, {nameof(msg)} is null", LogArea.Comments);

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
@@ -69,7 +69,7 @@
                     @if (Model.LatestAnnouncement.Content.Length > 250)
                     {
                         <span style="white-space: pre-line">
-                            @Model.LatestAnnouncement.Content[..250]
+                            @Model.LatestAnnouncement.Content[..250]...
                             <a href="@ServerConfiguration.Instance.ExternalUrl/notifications">read more</a>
                         </span>
                     }

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
@@ -67,9 +67,13 @@
             <h3>@Model.LatestAnnouncement.Title</h3>
             <div style="padding-bottom: 2em;">
                 <span style="white-space: pre-line">
-                    @(Model.LatestAnnouncement.Content.Length > 250
-                        ? Model.LatestAnnouncement.Content[..250] + $"... [read more]({ServerConfiguration.Instance.ExternalUrl}/notifications)"
-                        : Model.LatestAnnouncement.Content)
+                    @{
+                        string truncatedAnnouncement = Model.LatestAnnouncement.Content.Length > 250
+                            ? Model.LatestAnnouncement.Content[..250] +
+                              $"... <a href='{ServerConfiguration.Instance.ExternalUrl}/notifications'>read more</a>"
+                            : Model.LatestAnnouncement.Content;
+                    }
+                    @Html.Raw(truncatedAnnouncement)
                 </span>
             </div>
             @if (Model.LatestAnnouncement.Publisher != null)

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
@@ -66,15 +66,19 @@
         <div>
             <h3>@Model.LatestAnnouncement.Title</h3>
             <div style="padding-bottom: 2em;">
-                <span style="white-space: pre-line">
-                    @{
-                        string truncatedAnnouncement = Model.LatestAnnouncement.Content.Length > 250
-                            ? Model.LatestAnnouncement.Content[..250] +
-                              $"... <a href='{ServerConfiguration.Instance.ExternalUrl}/notifications'>read more</a>"
-                            : Model.LatestAnnouncement.Content;
+                    @if (Model.LatestAnnouncement.Content.Length > 250)
+                    {
+                        <span style="white-space: pre-line">
+                            @Model.LatestAnnouncement.Content[..250]
+                            <a href="@ServerConfiguration.Instance.ExternalUrl/notifications">read more</a>
+                        </span>
                     }
-                    @Html.Raw(truncatedAnnouncement)
-                </span>
+                    else
+                    {
+                        <span style="white-space: pre-line">
+                            @Model.LatestAnnouncement.Content
+                        </span>
+                    }
             </div>
             @if (Model.LatestAnnouncement.Publisher != null)
             {

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml
@@ -60,7 +60,34 @@
     }
 }
 
-<br><br>
+@if (Model.LatestAnnouncement != null)
+{
+    <div class="ui blue segment" style="position: relative;">
+        <div>
+            <h3>@Model.LatestAnnouncement.Title</h3>
+            <div style="padding-bottom: 2em;">
+                <span style="white-space: pre-line">
+                    @(Model.LatestAnnouncement.Content.Length > 250
+                        ? Model.LatestAnnouncement.Content[..250] + $"... [read more]({ServerConfiguration.Instance.ExternalUrl}/notifications)"
+                        : Model.LatestAnnouncement.Content)
+                </span>
+            </div>
+            @if (Model.LatestAnnouncement.Publisher != null)
+            {
+                <div class="ui tiny bottom left attached label">
+                    Posted by
+                    <a style="color: black" href="~/user/@Model.LatestAnnouncement.Publisher.UserId">
+                        @Model.LatestAnnouncement.Publisher.Username
+                    </a>
+                </div>
+            }
+        </div>
+    </div>
+}
+else
+{
+    <br /><br />
+}
 
 <div class="@(isMobile ? "" : "ui center aligned grid")">
     <div class="eight wide column">

--- a/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/LandingPage.cshtml.cs
@@ -5,6 +5,7 @@ using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.Website.Pages.Layouts;
 using LBPUnion.ProjectLighthouse.Types.Entities.Level;
 using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
+using LBPUnion.ProjectLighthouse.Types.Entities.Website;
 using LBPUnion.ProjectLighthouse.Types.Levels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -18,6 +19,8 @@ public class LandingPage : BaseLayout
 
     public int PendingAuthAttempts;
     public List<UserEntity> PlayersOnline = new();
+
+    public WebsiteAnnouncementEntity? LatestAnnouncement;
 
     public LandingPage(DatabaseContext database) : base(database)
     { }
@@ -53,6 +56,10 @@ public class LandingPage : BaseLayout
             .Take(maxShownLevels)
             .Include(s => s.Creator)
             .ToListAsync();
+
+        this.LatestAnnouncement = await this.Database.WebsiteAnnouncements.Include(a => a.Publisher)
+            .OrderByDescending(a => a.AnnouncementId)
+            .FirstOrDefaultAsync();
 
         return this.Page();
     }

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -178,6 +178,18 @@
                 </div>
             </div>
         }
+        @if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+        {
+            <div class="ui bottom attached red message large">
+                <div class="ui container">
+                    <i class="warning icon"></i>
+                    <span style="font-size: 1.2rem;">@Model.Translate(BaseLayoutStrings.ReadOnlyWarnTitle)</span>
+                    <p>
+                        @Html.Raw(Model.Translate(BaseLayoutStrings.ReadOnlyWarn))
+                    </p>
+                </div>
+            </div>
+        }
     </header>
     <div class="main">
         <div class="ui container">

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/CommentsPartial.cshtml
@@ -1,4 +1,5 @@
 ﻿@using System.Web
+@using LBPUnion.ProjectLighthouse.Configuration
 @using LBPUnion.ProjectLighthouse.Database
 @using LBPUnion.ProjectLighthouse.Localization
 @using LBPUnion.ProjectLighthouse.Servers.Website.Extensions
@@ -31,18 +32,32 @@
     @if (Model.CommentsEnabled && Model.User != null)
     {
         <div class="ui divider"></div>
-        <form class="ui reply form" action="postComment" method="post">
-            <div class="field">
-                <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
+        @if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+        {
+            <div class="ui red segment">
+                <p>
+                    <i>
+                        @ServerConfiguration.Instance.Customization.ServerName is currently in read-only mode.
+                        You will not be able to post comments until read-only mode is disabled.
+                    </i>
+                </p>
             </div>
-            <input type="submit" class="ui blue button">
-        </form>
+        }
+        else
+        {
+            <form class="ui reply form" action="postComment" method="post">
+                <div class="field">
+                    <textarea style="min-height: 70px; height: 70px; max-height:120px" maxlength="100" name="msg"></textarea>
+                </div>
+                <input type="submit" class="ui blue button">
+            </form>
+        }
         @if (Model.Comments.Count > 0)
         {
             <div class="ui divider"></div>
         }
     }
-    
+
     @{
         int i = 0;
         foreach (KeyValuePair<CommentEntity, RatedCommentEntity?> commentAndReaction in Model.Comments)

--- a/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Partials/ReviewPartial.cshtml
@@ -4,7 +4,6 @@
 @using LBPUnion.ProjectLighthouse.Helpers
 @using LBPUnion.ProjectLighthouse.Types.Entities.Level
 @using LBPUnion.ProjectLighthouse.Types.Serialization
-
 @{
     bool isMobile = (bool?)ViewData["IsMobile"] ?? false;
     bool canDelete = (bool?)ViewData["CanDelete"] ?? false;
@@ -29,6 +28,18 @@
                 <div class="ui divider"></div>
             }
 
+            @if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+            {
+                <div class="ui red segment">
+                    <p>
+                        <i>
+                            @ServerConfiguration.Instance.Customization.ServerName is currently in read-only mode.
+                            You will not be able to post reviews in-game until read-only mode is disabled.
+                        </i>
+                    </p>
+                </div>
+            }
+
             @for(int i = 0; i < Model.Reviews.Count; i++)
             {
                 ReviewEntity review = Model.Reviews[i];
@@ -36,7 +47,7 @@
                     -1 => review.Reviewer?.BooHash,
                     0 => review.Reviewer?.MehHash,
                     1 => review.Reviewer?.YayHash,
-                    
+
                     _ => throw new ArgumentOutOfRangeException(),
                     }) ?? "";
 
@@ -49,7 +60,7 @@
                     -1 => "Boo!",
                     0 => "Meh.",
                     1 => "Yay!",
-                    
+
                     _ => throw new ArgumentOutOfRangeException(),
                     };
 
@@ -114,7 +125,7 @@
                                 if (window.confirm("Are you sure you want to delete this?\nThis action cannot be undone.")){
                                     window.location.hash = "reviews";
                                     window.location.href = "/moderation/deleteReview/" + reviewId + "?callbackUrl=" + this.window.location;
-                                }          
+                                }
                             }
                         </script>
                         </div>

--- a/ProjectLighthouse.Servers.Website/Pages/SlotSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/SlotSettingsPage.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Files;
 using LBPUnion.ProjectLighthouse.Helpers;
@@ -25,6 +26,10 @@ public class SlotSettingsPage : BaseLayout
 
         if (!this.User.IsModerator && this.User != this.Slot.Creator) return this.Redirect("~/slot/" + slotId);
 
+        // Deny request if in read-only mode
+        if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+            return this.Redirect($"~/slot/{slotId}");
+
         string? avatarHash = await FileHelper.ParseBase64Image(avatar);
 
         if (avatarHash != null) this.Slot.IconHash = avatarHash;
@@ -46,7 +51,7 @@ public class SlotSettingsPage : BaseLayout
         if (labels != null)
         {
             labels = LabelHelper.RemoveInvalidLabels(labels);
-            if (this.Slot.AuthorLabels != labels) 
+            if (this.Slot.AuthorLabels != labels)
                 this.Slot.AuthorLabels = labels;
         }
 

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -39,15 +39,13 @@ public class UserSettingsPage : BaseLayout
 
         if (!this.User.IsModerator && this.User != this.ProfileUser) return this.Redirect("~/user/" + userId);
 
+        // Deny request if in read-only mode
+        if (avatar != null && ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+            return this.Redirect($"~/user/{userId}");
+
         string? avatarHash = await FileHelper.ParseBase64Image(avatar);
 
-        if (avatarHash != null)
-        {
-            // Deny request if in read-only mode
-            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect($"~/user/{userId}");
-
-            this.ProfileUser.IconHash = avatarHash;
-        }
+        if (avatarHash != null) this.ProfileUser.IconHash = avatarHash;
 
         if (this.User.IsAdmin) this.ProfileUser.ProfileTag = profileTag;
 

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -44,7 +44,7 @@ public class UserSettingsPage : BaseLayout
         if (avatarHash != null)
         {
             // Deny request if in read-only mode
-            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect($"~/user/{userId}");
 
             this.ProfileUser.IconHash = avatarHash;
         }
@@ -54,7 +54,7 @@ public class UserSettingsPage : BaseLayout
         if (biography != null)
         {
             // Deny request if in read-only mode
-            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect($"~/user/{userId}");
 
             biography = CensorHelper.FilterMessage(biography);
             if (this.ProfileUser.Biography != biography && biography.Length <= 512)

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -52,7 +52,8 @@ public class UserSettingsPage : BaseLayout
         if (biography != null)
         {
             // Deny request if in read-only mode
-            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.Redirect($"~/user/{userId}");
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
+                return this.Redirect($"~/user/{userId}");
 
             biography = CensorHelper.FilterMessage(biography);
             if (this.ProfileUser.Biography != biography && biography.Length <= 512)

--- a/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
+++ b/ProjectLighthouse.Servers.Website/Pages/UserSettingsPage.cshtml.cs
@@ -41,12 +41,21 @@ public class UserSettingsPage : BaseLayout
 
         string? avatarHash = await FileHelper.ParseBase64Image(avatar);
 
-        if (avatarHash != null) this.ProfileUser.IconHash = avatarHash;
+        if (avatarHash != null)
+        {
+            // Deny request if in read-only mode
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
+            this.ProfileUser.IconHash = avatarHash;
+        }
 
         if (this.User.IsAdmin) this.ProfileUser.ProfileTag = profileTag;
 
         if (biography != null)
         {
+            // Deny request if in read-only mode
+            if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode) return this.BadRequest();
+
             biography = CensorHelper.FilterMessage(biography);
             if (this.ProfileUser.Biography != biography && biography.Length <= 512)
                 this.ProfileUser.Biography = biography;

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/UserGeneratedContentLimitConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/UserGeneratedContentLimitConfiguration.cs
@@ -11,6 +11,12 @@ public class UserGeneratedContentLimitConfiguration
 
     public int PhotosQuota { get; set; } = 500;
 
+    /// <summary>
+    ///     When enabled, all UGC uploads are disabled. This includes levels, photos, reviews,
+    ///     comments, and certain profile settings.
+    /// </summary>
+    public bool ReadOnlyMode { get; set; } = false;
+
     public bool ProfileCommentsEnabled { get; set; } = true;
 
     public bool LevelCommentsEnabled { get; set; } = true;

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -11,7 +11,7 @@ public class ServerConfiguration : ConfigurationBase<ServerConfiguration>
     // This is so Lighthouse can properly identify outdated configurations and update them with newer settings accordingly.
     // If you are modifying anything here, this value MUST be incremented.
     // Thanks for listening~
-    public override int ConfigVersion { get; set; } = 25;
+    public override int ConfigVersion { get; set; } = 26;
 
     public override string ConfigName { get; set; } = "lighthouse.yml";
     public string WebsiteListenUrl { get; set; } = "http://localhost:10060";


### PR DESCRIPTION
This PR implements the ability to put an instance in a "read-only" state.

The following actions are limited or disabled while in read-only mode:
* Level uploads or changes
* Photo uploads
* General asset uploads (/upload/hash)
* Profile picture/biography changes
* Post/delete comments
* Post/delete reviews

A message will also be appended to the base website layout, as well as the /announce endpoint.

This could probably be refactored into a simple middleware or something in the future.