### PR TITLE
Update StatisticsEndpoints.cs

### DIFF
--- a/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
@@ -36,6 +36,7 @@ public class StatisticsEndpoints : ApiEndpointController
                 Slots = await StatisticsHelper.SlotCount(this.database, new SlotQueryBuilder()),
                 Users = await StatisticsHelper.UserCount(this.database),
                 RecentMatches = await StatisticsHelper.RecentMatches(this.database),
+                RoomsPerPlatform = await StatisticsHelper.RoomCountPerPlatform(this.database),
                 TeamPicks = await StatisticsHelper.SlotCount(this.database, new SlotQueryBuilder().AddFilter(new TeamPickFilter())),
             }
         );


### PR DESCRIPTION
Uhhh I hope this change adds the ability for the api to report the number of rooms per platform. I really don't know what I'm doing so I'll explain what I did.

I discovered this line in StatisticsHelper.cs

`public static int RoomCountForPlatform(Platform targetPlatform) => RoomHelper.Rooms.Count(r => r.IsLookingForPlayers && r.RoomPlatform == targetPlatform);`

I followed the general pattern that I found in StatisticsEndpoint for the other data points that are added into the API. I don't fully understand how it works, but I assume it's something like this:

1. RoomsPerPlatform: declares the name of the endpoint
2. await (waits for changes)
3. StatisticsHelper.RoomCountPerPlatform looks for the method(?) in StatisticsHelper.cs. We are awaiting a change in this method.
4. (this.database) I'm guessing this is the name of the database that it's storing the information in? Or maybe it's a relative reference, such as using the 'current' database that's already being used. 

I noticed some of the other lines nearby have other information like new SlotQueryBuilder(), so it's possible I'm missing something. I omitted that because this change doesn't have anything to do with slots. But, if there's other stuff that needs to happen related to rooms, then maybe more needs to be changed. 

I also committed the grave sin of creating this PR using the GitHub text editor because I couldn't figure out how to load the file in VS Code. I will now go hide in the box of shame. Hopefully I didn't screw anything up with contributor guidelines 