### PR TITLE
Implement player count per platform and player list API endpoints

### DIFF
--- a/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
@@ -61,7 +61,7 @@ public class StatisticsEndpoints : ApiEndpointController
     /// <summary>
     /// Get player counts for each individual title
     /// </summary>
-    /// <returns>An instance of PlayerCountResponse</returns>
+    /// <returns>An instance of PlayerCountByGameResponse</returns>
     [HttpGet("playerCount")]
     [HttpGet("playerCount/game")]
     [ProducesResponseType(typeof(PlayerCountByGameResponse), StatusCodes.Status200OK)]
@@ -86,9 +86,9 @@ public class StatisticsEndpoints : ApiEndpointController
     }
 
     /// <summary>
-    /// Get player counts for each individual title
+    /// Get player counts for each individual platform
     /// </summary>
-    /// <returns>An instance of PlayerCountResponse</returns>
+    /// <returns>An instance of PlayerCountByPlatformResponse</returns>
     [HttpGet("playerCount/platform")]
     [ProducesResponseType(typeof(PlayerCountByPlatformResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPlayerCountsByPlatform()
@@ -115,7 +115,7 @@ public class StatisticsEndpoints : ApiEndpointController
     /// <summary>
     /// Gets a list of online players 
     /// </summary>
-    /// <returns>An instance of PlayerCountResponse</returns>
+    /// <returns>An instance of PlayerListResponse</returns>
     [HttpGet("players")]
     [ProducesResponseType(typeof(PlayerListResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPlayerList()

--- a/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
+++ b/ProjectLighthouse.Servers.API/Controllers/StatisticsEndpoints.cs
@@ -5,6 +5,7 @@ using LBPUnion.ProjectLighthouse.Helpers;
 using LBPUnion.ProjectLighthouse.Servers.API.Responses;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace LBPUnion.ProjectLighthouse.Servers.API.Controllers;
 
@@ -49,27 +50,88 @@ public class StatisticsEndpoints : ApiEndpointController
         GameVersion.LittleBigPlanetPSP,
     };
 
+    private static readonly List<Platform> platforms = new()
+    {
+        Platform.PS3,
+        Platform.RPCS3,
+        Platform.Vita,
+        Platform.PSP,
+    };
+
     /// <summary>
     /// Get player counts for each individual title
     /// </summary>
     /// <returns>An instance of PlayerCountResponse</returns>
     [HttpGet("playerCount")]
-    [ProducesResponseType(typeof(PlayerCountResponse), StatusCodes.Status200OK)]
+    [HttpGet("playerCount/game")]
+    [ProducesResponseType(typeof(PlayerCountByGameResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetPlayerCounts()
     {
         List<PlayerCountObject> gameList = new();
         foreach (GameVersion version in gameVersions)
         {
-            gameList.Add(new PlayerCountObject
+            gameList.Add(new PlayerCountByGameObject
             {
                 Game = version.ToString(),
-                PlayerCount = await StatisticsHelper.RecentMatchesForGame(this.database, version),
+                PlayerCount = await StatisticsHelper.RecentMatches(this.database, l => l.GameVersion == version),
             });
         }
-        PlayerCountResponse response = new()
+        PlayerCountByGameResponse response = new()
         {
             TotalPlayerCount = await StatisticsHelper.RecentMatches(this.database),
             Games = gameList,
+        };
+
+        return this.Ok(response);
+    }
+
+    /// <summary>
+    /// Get player counts for each individual title
+    /// </summary>
+    /// <returns>An instance of PlayerCountResponse</returns>
+    [HttpGet("playerCount/platform")]
+    [ProducesResponseType(typeof(PlayerCountByPlatformResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPlayerCountsByPlatform()
+    {
+        List<PlayerCountObject> platformList = new();
+        foreach (Platform platform in platforms)
+        {
+            platformList.Add(new PlayerCountByPlatformObject
+            {
+                Platform = platform.ToString(),
+                PlayerCount = await StatisticsHelper.RecentMatches(this.database, l => l.Platform == platform),
+            });
+        }
+
+        PlayerCountByPlatformResponse response = new()
+        {
+            TotalPlayerCount = await StatisticsHelper.RecentMatches(this.database),
+            Platforms = platformList,
+        };
+
+        return this.Ok(response);
+    }
+
+    /// <summary>
+    /// Gets a list of online players 
+    /// </summary>
+    /// <returns>An instance of PlayerCountResponse</returns>
+    [HttpGet("players")]
+    [ProducesResponseType(typeof(PlayerListResponse), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPlayerList()
+    {
+        List<PlayerListObject> players = await this.database.LastContacts.Where(l => TimeHelper.Timestamp - l.Timestamp < 300)
+            .Select(l => new PlayerListObject
+            {
+                Username = l.User!.Username,
+                Game = l.GameVersion.ToString(),
+                Platform = l.Platform.ToString(),
+            })
+            .ToListAsync();
+
+        PlayerListResponse response = new()
+        {
+            Players = players,
         };
 
         return this.Ok(response);

--- a/ProjectLighthouse.Servers.API/Responses/PlayerCountResponse.cs
+++ b/ProjectLighthouse.Servers.API/Responses/PlayerCountResponse.cs
@@ -1,13 +1,37 @@
-﻿namespace LBPUnion.ProjectLighthouse.Servers.API.Responses;
+﻿using System.Text.Json.Serialization;
 
+namespace LBPUnion.ProjectLighthouse.Servers.API.Responses;
+
+[JsonDerivedType(typeof(PlayerCountByGameObject))]
+[JsonDerivedType(typeof(PlayerCountByPlatformObject))]
 public class PlayerCountObject
 {
-    public string Game { get; set; } = "";
     public int PlayerCount { get; set; }
 }
 
+public class PlayerCountByGameObject : PlayerCountObject
+{
+    public string Game { get; set; } = "";
+}
+
+public class PlayerCountByPlatformObject : PlayerCountObject
+{
+    public string Platform { get; set; } = "";
+}
+
+[JsonDerivedType(typeof(PlayerCountByGameResponse))]
+[JsonDerivedType(typeof(PlayerCountByPlatformResponse))]
 public class PlayerCountResponse
 {
     public int TotalPlayerCount { get; set; }
+}
+
+public class PlayerCountByGameResponse : PlayerCountResponse
+{
     public List<PlayerCountObject> Games { get; set; } = new();
+}
+
+public class PlayerCountByPlatformResponse : PlayerCountResponse
+{
+    public List<PlayerCountObject> Platforms { get; set; } = new();
 }

--- a/ProjectLighthouse.Servers.API/Responses/PlayerListResponse.cs
+++ b/ProjectLighthouse.Servers.API/Responses/PlayerListResponse.cs
@@ -1,0 +1,13 @@
+namespace LBPUnion.ProjectLighthouse.Servers.API.Responses;
+
+public class PlayerListResponse
+{
+    public required List<PlayerListObject> Players { get; set; }
+}
+
+public class PlayerListObject
+{
+    public required string Username { get; set; }
+    public required string Game { get; set; }
+    public required  string Platform { get; set; }
+}

--- a/ProjectLighthouse.Servers.API/Responses/PlayerListResponse.cs
+++ b/ProjectLighthouse.Servers.API/Responses/PlayerListResponse.cs
@@ -9,5 +9,5 @@ public class PlayerListObject
 {
     public required string Username { get; set; }
     public required string Game { get; set; }
-    public required  string Platform { get; set; }
+    public required string Platform { get; set; }
 }

--- a/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/StatisticsController.cs
@@ -27,7 +27,8 @@ public class StatisticsController : ControllerBase
     public IActionResult PlayersInPodCount() => this.Ok(StatisticsHelper.RoomCountForPlatform(this.GetToken().Platform).ToString());
 
     [HttpGet("totalPlayerCount")]
-    public async Task<IActionResult> TotalPlayerCount() => this.Ok((await StatisticsHelper.RecentMatchesForGame(this.database, this.GetToken().GameVersion)).ToString());
+    public async Task<IActionResult> TotalPlayerCount() =>
+        this.Ok((await StatisticsHelper.RecentMatches(this.database, l => l.GameVersion == this.GetToken().GameVersion)).ToString());
 
     [HttpGet("planetStats")]
     [Produces("text/xml")]

--- a/ProjectLighthouse/Helpers/StatisticsHelper.cs
+++ b/ProjectLighthouse/Helpers/StatisticsHelper.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using LBPUnion.ProjectLighthouse.Database;
 using LBPUnion.ProjectLighthouse.Filter;
+using LBPUnion.ProjectLighthouse.Types.Entities.Profile;
 using LBPUnion.ProjectLighthouse.Types.Users;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,8 +14,8 @@ public static class StatisticsHelper
 {
     public static async Task<int> RecentMatches(DatabaseContext database) => await database.LastContacts.Where(l => TimeHelper.Timestamp - l.Timestamp < 300).CountAsync();
 
-    public static async Task<int> RecentMatchesForGame(DatabaseContext database, GameVersion gameVersion)
-        => await database.LastContacts.Where(l => TimeHelper.Timestamp - l.Timestamp < 300 && l.GameVersion == gameVersion).CountAsync();
+    public static async Task<int> RecentMatches(DatabaseContext database, Expression<Func<LastContactEntity, bool>> contactFilter) =>
+        await database.LastContacts.Where(l => TimeHelper.Timestamp - l.Timestamp < 300).Where(contactFilter).CountAsync();
 
     public static async Task<int> SlotCount(DatabaseContext database, SlotQueryBuilder queryBuilder) => await database.Slots.Where(queryBuilder.Build()).CountAsync();
 


### PR DESCRIPTION
This PR adds new endpoints to the v1 API to support fetching player counts grouped by platform as well as fetching the entire list of online users.

Example `/api/v1/players` response:
```json
{
  "players": [
    {
      "username": "Slendy",
      "game": "LittleBigPlanet2",
      "platform": "RPCS3"
    }
  ]
}
```
Example `/api/v1/playerCount/platform` response:
```json
{
  "platforms": [
    {
      "platform": "PS3",
      "playerCount": 0
    },
    {
      "platform": "RPCS3",
      "playerCount": 1
    },
    {
      "platform": "Vita",
      "playerCount": 0
    },
    {
      "platform": "PSP",
      "playerCount": 0
    }
  ],
  "totalPlayerCount": 1
}
```