### PR TITLE
Prevent LBP3 reviews from showing up in LBP2

### DIFF
--- a/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ReviewController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Slots/ReviewController.cs
@@ -157,6 +157,13 @@ public class ReviewController : ControllerBase
 
         List<GameReview> reviews = (await this.database.Reviews
             .Where(r => r.SlotId == slotId)
+            .Select(r => new
+            {
+                Review = r,
+                SlotVersion = r.Slot!.GameVersion,
+            })
+            .Where(a => a.SlotVersion <= token.GameVersion)
+            .Select(a => a.Review)
             .OrderByDescending(r => r.ThumbsUp - r.ThumbsDown)
             .ThenByDescending(r => r.Timestamp)
             .ApplyPagination(pageData)
@@ -178,6 +185,13 @@ public class ReviewController : ControllerBase
 
         List<GameReview> reviews = (await this.database.Reviews
             .Where(r => r.ReviewerId == targetUserId)
+            .Select(r => new
+            {
+                Review = r,
+                SlotVersion = r.Slot!.GameVersion,
+            })
+            .Where(a => a.SlotVersion <= token.GameVersion)
+            .Select(a => a.Review)
             .OrderByDescending(r => r.Timestamp)
             .ApplyPagination(pageData)
             .ToListAsync()).ToSerializableList(r => GameReview.CreateFromEntity(r, token));

--- a/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/ReviewControllerTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Unit/Controllers/ReviewControllerTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LBPUnion.ProjectLighthouse.Database;
+using LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Slots;
+using LBPUnion.ProjectLighthouse.Tests.Helpers;
+using LBPUnion.ProjectLighthouse.Types.Entities.Level;
+using LBPUnion.ProjectLighthouse.Types.Entities.Token;
+using LBPUnion.ProjectLighthouse.Types.Serialization;
+using LBPUnion.ProjectLighthouse.Types.Users;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace ProjectLighthouse.Tests.GameApiTests.Unit.Controllers;
+
+public class ReviewControllerTests
+{
+    private static async Task InsertTestData(DatabaseContext database)
+    {
+        database.Slots.Add(new SlotEntity
+        {
+            SlotId = 1,
+            CreatorId = 1,
+            GameVersion = GameVersion.LittleBigPlanet3,
+        });
+
+        database.Slots.Add(new SlotEntity
+        {
+            SlotId = 2,
+            CreatorId = 1,
+            GameVersion = GameVersion.LittleBigPlanet2,
+        });
+
+        database.Reviews.Add(new ReviewEntity
+        {
+            ReviewId = 1,
+            ReviewerId = 1,
+            SlotId = 1,
+        });
+
+        database.Reviews.Add(new ReviewEntity
+        {
+            ReviewId = 2,
+            ReviewerId = 1,
+            SlotId = 2,
+        });
+        await database.SaveChangesAsync();
+    }
+
+    [Theory]
+    [InlineData(GameVersion.LittleBigPlanet2, 1)]
+    [InlineData(GameVersion.LittleBigPlanet3, 2)]
+    public async Task ReviewsBy_ShouldNotList_HigherGameVersions(GameVersion version, int expected)
+    {
+        GameTokenEntity token = MockHelper.GetUnitTestToken();
+        token.GameVersion = version;
+        DatabaseContext database = await MockHelper.GetTestDatabase(new List<GameTokenEntity>
+        {
+            token,
+        });
+
+        await InsertTestData(database);
+
+        ReviewController controller = new(database);
+        controller.SetupTestController(token);
+
+        IActionResult response = await controller.ReviewsBy("unittest");
+        ReviewResponse review = response.CastTo<OkObjectResult, ReviewResponse>();
+
+        Assert.Equal(expected, review.Reviews.Count);
+        Assert.True(review.Reviews.All(r => database.Slots.FirstOrDefault(s => s.SlotId == r.Slot.SlotId)?.GameVersion <= version));
+    }
+
+    [Theory]
+    [InlineData(GameVersion.LittleBigPlanet2, 2, 1)]
+    [InlineData(GameVersion.LittleBigPlanet2, 1, 0)]
+    [InlineData(GameVersion.LittleBigPlanet3, 2, 1)]
+    [InlineData(GameVersion.LittleBigPlanet3, 1, 1)]
+    public async Task ReviewsFor_ShouldNotList_HigherGameVersions(GameVersion version, int slotId, int expected)
+    {
+        GameTokenEntity token = MockHelper.GetUnitTestToken();
+        token.GameVersion = version;
+        DatabaseContext database = await MockHelper.GetTestDatabase(new List<GameTokenEntity>
+        {
+            token,
+        });
+
+        await InsertTestData(database);
+
+        ReviewController controller = new(database);
+        controller.SetupTestController(token);
+
+        IActionResult response = await controller.ReviewsFor(slotId);
+        ReviewResponse review = response.CastTo<OkObjectResult, ReviewResponse>();
+
+        Assert.Equal(expected, review.Reviews.Count);
+        Assert.True(review.Reviews.All(r => database.Slots.FirstOrDefault(s => s.SlotId == r.Slot.SlotId)?.GameVersion <= version));
+    }
+}


### PR DESCRIPTION
There is currently a bug where if you review an LBP3 level and load your profile in LBP2 the game freaks out because the level data won't be returned because of the GameVersionFilter. This PR adds similar filtering so that reviews from higher game versions are no longer returned. This change adds an extra SQL join to the review query.

new example generated query:
```sql
.param set @__targetUserId_0 1
.param set @__token_GameVersion_1 1

SELECT "r"."ReviewId", "r"."Deleted", "r"."DeletedBy", "r"."LabelCollection", "r"."ReviewerId", "r"."SlotId", "r"."Text", "r"."Thumb", "r"."ThumbsDown", "r"."ThumbsUp", "r"."Timestamp"
FROM "Reviews" AS "r"
INNER JOIN "Slots" AS "s" ON "r"."SlotId" = "s"."SlotId"
WHERE "r"."ReviewerId" = @__targetUserId_0 AND "s"."GameVersion" <= @__token_GameVersion_1
ORDER BY "r"."Timestamp" DESC
```