### PR TITLE
Implement the ability for moderators to delete all scores/comments by a user

### DIFF
--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -118,8 +118,6 @@ public class AdminUserController : ControllerBase
         await this.database.SendNotification(targetedUser.UserId,
             "Your comments have been deleted by a moderator.");
 
-        await this.database.SaveChangesAsync();
-
         return this.Redirect($"/user/{targetedUser.UserId}");
     }
 
@@ -140,8 +138,6 @@ public class AdminUserController : ControllerBase
         Logger.Success($"Deleted scores for {targetedUser.Username} (id:{targetedUser.UserId})", LogArea.Admin);
 
         await this.database.SendNotification(targetedUser.UserId, "Your scores have been deleted by a moderator.");
-
-        await this.database.SaveChangesAsync();
 
         return this.Redirect($"/user/{targetedUser.UserId}");
     }

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -118,9 +118,8 @@ public class AdminUserController : ControllerBase
             comment.Deleted = true;
             comment.DeletedBy = user.Username;
             comment.DeletedType = "moderator";
-            Logger.Success($"Deleted comments for {targetedUser.Username} (id:{targetedUser.UserId})",
-                LogArea.Admin);
         }
+        Logger.Success($"Deleted comments for {targetedUser.Username} (id:{targetedUser.UserId})", LogArea.Admin);
 
         await this.database.SendNotification(targetedUser.UserId,
             "Your comments have been deleted by a moderator.");

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -142,7 +142,7 @@ public class AdminUserController : ControllerBase
         if (targetedUser == null) return this.NotFound();
 
         // Find and delete every score uploaded by the target user
-        await this.database.Scores.RemoveWhere(c => c.User == targetedUser);
+        await this.database.Scores.Where(c => c.UserId == targetedUser.UserId).ExecuteDeleteAsync();
         Logger.Success($"Deleted scores for {targetedUser.Username} (id:{targetedUser.UserId})", LogArea.Admin);
 
         await this.database.SendNotification(targetedUser.UserId, "Your scores have been deleted by a moderator.");

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -29,7 +29,8 @@ public class AdminUserController : ControllerBase
     /// Resets the user's earth decorations to a blank state. Useful for users who abuse audio for example.
     /// </summary>
     [HttpGet("wipePlanets")]
-    public async Task<IActionResult> WipePlanets([FromRoute] int id) {
+    public async Task<IActionResult> WipePlanets([FromRoute] int id)
+    {
         UserEntity? user = this.database.UserFromWebRequest(this.Request);
         if (user == null || !user.IsModerator) return this.NotFound();
 
@@ -98,7 +99,8 @@ public class AdminUserController : ControllerBase
     /// Deletes every comment by the user. Useful in case of mass spam
     /// </summary>
     [HttpGet("wipeComments")]
-    public async Task<IActionResult> WipeComments([FromRoute] int id) {
+    public async Task<IActionResult> WipeComments([FromRoute] int id)
+    {
         UserEntity? user = this.database.UserFromWebRequest(this.Request);
         if (user == null || !user.IsModerator) return this.NotFound();
 

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -324,6 +324,16 @@ else
             <i class="trash alternate icon"></i>
             <span>Wipe Earth Decorations</span>
         </a>
+        
+        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeComments">
+            <i class="trash alternate icon"></i>
+            <span>Wipe User's Comments</span>
+        </a>
+        
+        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeScores">
+            <i class="trash alternate icon"></i>
+            <span>Wipe User's Scores</span>
+        </a>
 
         @if (!Model.CommentsDisabledByModerator)
         {

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -325,12 +325,14 @@ else
             <span>Wipe Earth Decorations</span>
         </a>
         
-        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeComments">
+        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeComments" 
+           onclick="return confirm('Are you sure you want to delete ALL of this user\'s comments? This action cannot be reversed.')">
             <i class="trash alternate icon"></i>
             <span>Wipe User&apos;s Comments</span>
         </a>
         
-        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeScores">
+        <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeScores"
+           onclick="return confirm('Are you sure you want to delete ALL of this user\'s scores? This action cannot be reversed.')">
             <i class="trash alternate icon"></i>
             <span>Wipe User&apos;s Scores</span>
         </a>

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -327,12 +327,12 @@ else
         
         <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeComments">
             <i class="trash alternate icon"></i>
-            <span>Wipe User's Comments</span>
+            <span>Wipe User&apos;s Comments</span>
         </a>
         
         <a class="ui red button" href="/moderation/user/@Model.ProfileUser.UserId/wipeScores">
             <i class="trash alternate icon"></i>
-            <span>Wipe User's Scores</span>
+            <span>Wipe User&apos;s Scores</span>
         </a>
 
         @if (!Model.CommentsDisabledByModerator)


### PR DESCRIPTION
Title is fairly self-explanatory.
This PR allows moderators/admins to delete every score or comment posted by a user from the user page.
These features were requested by a Beacon moderator after some recent comment and hacked score spam.