### PR TITLE
Base64 encode auth tokens

### DIFF
--- a/ProjectLighthouse.Tests.GameApiTests/Integration/DatabaseTests.cs
+++ b/ProjectLighthouse.Tests.GameApiTests/Integration/DatabaseTests.cs
@@ -20,8 +20,8 @@ public class DatabaseTests : LighthouseServerTest<GameServerTestStartup>
 
         int rand = new Random().Next();
 
-        UserEntity userA = await database.CreateUser("unitTestUser" + rand, CryptoHelper.GenerateAuthToken());
-        UserEntity userB = await database.CreateUser("unitTestUser" + rand, CryptoHelper.GenerateAuthToken());
+        UserEntity userA = await database.CreateUser("unitTestUser" + rand, CryptoHelper.BCryptHash(CryptoHelper.GenerateAuthToken()));
+        UserEntity userB = await database.CreateUser("unitTestUser" + rand, CryptoHelper.BCryptHash(CryptoHelper.GenerateAuthToken()));
 
         Assert.NotNull(userA);
         Assert.NotNull(userB);

--- a/ProjectLighthouse/Helpers/CryptoHelper.cs
+++ b/ProjectLighthouse/Helpers/CryptoHelper.cs
@@ -19,7 +19,14 @@ public static class CryptoHelper
     public static string GenerateAuthToken()
     {
         byte[] bytes = (byte[])GenerateRandomBytes(256);
-        
+
+        return BCryptHash(Sha256Hash(bytes));
+    }
+
+    public static string GenerateUrlToken()
+    {
+        byte[] bytes = (byte[])GenerateRandomBytes(256);
+
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(BCryptHash(Sha256Hash(bytes))));
     }
 

--- a/ProjectLighthouse/Helpers/CryptoHelper.cs
+++ b/ProjectLighthouse/Helpers/CryptoHelper.cs
@@ -19,8 +19,8 @@ public static class CryptoHelper
     public static string GenerateAuthToken()
     {
         byte[] bytes = (byte[])GenerateRandomBytes(256);
-
-        return BCryptHash(Sha256Hash(bytes));
+        
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(BCryptHash(Sha256Hash(bytes))));
     }
 
     public static string ComputeDigest(string path, string authCookie, byte[] body, string digestKey, bool excludeBody = false)

--- a/ProjectLighthouse/Helpers/EmailHelper.cs
+++ b/ProjectLighthouse/Helpers/EmailHelper.cs
@@ -52,7 +52,7 @@ public static class SMTPHelper
         {
             Created = DateTime.UtcNow,
             UserId = user.UserId,
-            ResetToken = CryptoHelper.GenerateAuthToken(),
+            ResetToken = CryptoHelper.GenerateUrlToken(),
         };
 
         database.PasswordResetTokens.Add(token);
@@ -92,7 +92,7 @@ public static class SMTPHelper
         {
             UserId = user.UserId,
             User = user,
-            EmailToken = CryptoHelper.GenerateAuthToken(),
+            EmailToken = CryptoHelper.GenerateUrlToken(),
             ExpiresAt = DateTime.UtcNow.AddHours(6),
         };
 


### PR DESCRIPTION
Base64 encode auth tokens to make them more URL compatible, i.e when they are used in emails.

Fixes #1023
