### PR TITLE
Remove license check

### DIFF
--- a/ProjectLighthouse.Servers.Website/Pages/Debug/VersionInfoPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Debug/VersionInfoPage.cshtml
@@ -14,5 +14,4 @@
 <p><b>Branch</b>: @VersionHelper.Branch</p>
 <p><b>Build</b>: @VersionHelper.Build</p>
 <p><b>CommitHash</b>: @VersionHelper.CommitHash</p>
-<p><b>IsDirty</b>: @VersionHelper.IsDirty</p>
 <p><b>RepositoryUrl</b>: @VersionHelper.RepositoryUrl</p>

--- a/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/Layouts/BaseLayout.cshtml
@@ -158,26 +158,6 @@
                 </div>
             </div>
         </noscript>
-        @if (!ServerStatics.IsDebug() && VersionHelper.IsDirty)
-        {
-            <div class="ui bottom attached red message large">
-                <div class="ui container">
-                    <i class="warning icon"></i>
-                    <span style="font-size: 1.2rem;">@Model.Translate(BaseLayoutStrings.LicenseWarnTitle)</span>
-                    <p>
-                        @Html.Raw(Model.Translate(BaseLayoutStrings.LicenseWarn1,
-                            "<a href=\"https://github.com/LBPUnion/project-lighthouse/blob/main/LICENSE\">GNU Affero General Public License v3.0</a>"))
-                    </p>
-                    <p>
-                        @Html.Raw(Model.Translate(BaseLayoutStrings.LicenseWarn2,
-                            "<code>git status</code>", "<a href=\"https://github.com/LBPUnion/project-lighthouse/issues\">", "</a>"))
-                    </p>
-                    <p>
-                        @Html.Raw(Model.Translate(BaseLayoutStrings.LicenseWarn3))
-                    </p>
-                </div>
-            </div>
-        }
         @if (ServerConfiguration.Instance.UserGeneratedContentLimits.ReadOnlyMode)
         {
             <div class="ui bottom attached red message large">
@@ -234,10 +214,6 @@
                         <span class="ui text red">Cannot Detect Source Code</span>
                     }
                 </span>
-                @if (VersionHelper.IsDirty)
-                {
-                    <p>@Model.Translate(BaseLayoutStrings.GeneratedModified)</p>
-                }
             </div>
         </div>
         @if (ServerStatics.IsDebug())

--- a/ProjectLighthouse/Helpers/VersionHelper.cs
+++ b/ProjectLighthouse/Helpers/VersionHelper.cs
@@ -19,7 +19,6 @@ public static class VersionHelper
     public static string EnvVer => $"{ServerConfiguration.Instance.Customization.EnvironmentName} {FullRevision}";
     public static string FullVersion =>
         $"Project Lighthouse {ServerConfiguration.Instance.Customization.EnvironmentName} {Branch}@{CommitHash} {Build}";
-    public static bool IsDirty => ThisAssembly.Git.IsDirty;
     public static string RepositoryUrl => ThisAssembly.Git.RepositoryUrl;
 
     public const string Build =

--- a/ProjectLighthouse/StartupTasks.cs
+++ b/ProjectLighthouse/StartupTasks.cs
@@ -53,12 +53,6 @@ public static class StartupTasks
 
         // Version info depends on ServerConfig 
         Logger.Info($"You are running version {VersionHelper.FullVersion}", LogArea.Startup);
-        if (VersionHelper.IsDirty)
-        {
-            Logger.Warn("This is a modified version of Project Lighthouse. " +
-                        "Please make sure you are properly disclosing the source code to any users who may be using this instance.",
-                LogArea.Startup);
-        }
 
         Logger.Info("Connecting to the database...", LogArea.Startup);
 


### PR DESCRIPTION
Closes #1032.

---

It's quite annoying and doesn't really do anything, it can also trigger on people who didn't modify the source code.
It is also very easy to disable it by making a commit in the local repo or just by changing `IsDirty` to always return `true`