### PR TITLE
Add button and controller to remove user avatar

### DIFF
--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -155,6 +155,13 @@ public class AdminUserController : ControllerBase
         if (targetedUser == null) return this.NotFound();
 
         targetedUser.IconHash = "";
+        
+        await this.database.SaveChangesAsync();
+        Logger.Success($"Reset profile picture for {targetedUser.Username} (id:{targetedUser.UserId})", LogArea.Admin);
+
+        await this.database.SendNotification(targetedUser.UserId, "Your profile picture has been reset by a moderator.");
+        
+        return this.Redirect($"/user/{targetedUser.UserId}");
     }
 
     /// <summary>

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -148,7 +148,7 @@ public class AdminUserController : ControllerBase
     [HttpGet("wipeAvatar")]
     public async Task<IActionResult> WipeAvatar([FromRoute] int id)
     {
-        UserEntity? user = this.database.UserFromWebRequest(this.request);
+        UserEntity? user = this.database.UserFromWebRequest(this.Request);
         if (user == null || !user.IsModerator) return this.NotFound();
 
         UserEntity? targetedUser = await this.database.Users.FirstOrDefaultAsync(u => u.UserId == id);

--- a/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
+++ b/ProjectLighthouse.Servers.Website/Controllers/Admin/AdminUserController.cs
@@ -143,7 +143,22 @@ public class AdminUserController : ControllerBase
     }
 
     /// <summary>
-    ///     Forces the email verification of a user.
+    /// Deletes the user's current avatar. Can prevent crashes in-game, or just be used to remove images that break guidelines.
+    /// </summary>
+    [HttpGet("wipeAvatar")]
+    public async Task<IActionResult> WipeAvatar([FromRoute] int id)
+    {
+        UserEntity? user = this.database.UserFromWebRequest(this.request);
+        if (user == null || !user.IsModerator) return this.NotFound();
+
+        UserEntity? targetedUser = await this.database.Users.FirstOrDefaultAsync(u => u.UserId == id);
+        if (targetedUser == null) return this.NotFound();
+
+        targetedUser.IconHash = "";
+    }
+
+    /// <summary>
+    /// Forces the email verification of a user.
     /// </summary>
     [HttpGet("forceVerifyEmail")]
     public async Task<IActionResult> ForceVerifyEmail([FromRoute] int id)

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -337,6 +337,11 @@ else
             <span>Wipe User&apos;s Scores</span>
         </a>
 
+        <a class="ui yellow button" href="/moderation/user/@Model.ProfileUser.UserId/wipeAvatar">
+            <i class="trash alternate icon"></i>
+            <span>Remove User Avatar</span>
+        </a>
+
         @if (!Model.CommentsDisabledByModerator)
         {
             <a class="ui yellow button" href="/moderation/newCase?type=@((int)CaseType.UserDisableComments)&affectedId=@Model.ProfileUser.UserId">


### PR DESCRIPTION
This button will just allow moderators and admins to remove the user avatar from a profile for either moderation, or other purposes. The main reason for implementation is to work around an issue where sometimes, loading profile images from the website in-game (at least in LBP2) can create major issues with loading any other images in-game, which usually leads to a crash. My best guess is that it's some sort of memory leak.