### PR TITLE
Identify NpTicket platform based on signature identifier instead of issuer ID

### DIFF
--- a/ProjectLighthouse/Tickets/NPTicket.cs
+++ b/ProjectLighthouse/Tickets/NPTicket.cs
@@ -78,19 +78,13 @@ public class NPTicket
 
         if (!ticketParser.ParseTicket()) return false;
 
-        // Create a uint in big endian
-        uint signatureIdentifier = (uint)(npTicket.TicketSignatureIdentifier[0] << 24 |
-                                          npTicket.TicketSignatureIdentifier[1] << 16 |
-                                          npTicket.TicketSignatureIdentifier[2] << 8 |
-                                          npTicket.TicketSignatureIdentifier[3]);
-
-        npTicket.SignatureVerifier = signatureIdentifier switch
+        npTicket.SignatureVerifier = npTicket.TicketSignatureIdentifier switch
         {
-            0x5250434E => new RpcnSignatureVerifier(npTicket),
-            0x719F1D4A => new PsnSignatureVerifier(npTicket),
-            0x54455354 => new UnitTestSignatureVerifier(npTicket),
+            [0x71, 0x9F, 0x1D, 0x4A,] => new PsnSignatureVerifier(npTicket), // PSN LBP Signature Identifier
+            [0x52, 0x50, 0x43, 0x4E,] => new RpcnSignatureVerifier(npTicket), // 'RPCN' in ascii
+            [0x54, 0x45, 0x53, 0x54,] => new UnitTestSignatureVerifier(npTicket), // 'TEST' in ascii
             _ => throw new ArgumentOutOfRangeException(nameof(npTicket),
-                signatureIdentifier,
+                npTicket.TicketSignatureIdentifier,
                 @"Invalid signature identifier"),
         };
 
@@ -159,18 +153,12 @@ public class NPTicket
                 return null;
             }
 
-            // Production PSN Issuer ID: 0x100
-            // The RPCN signature identifier is always 'RPCN' in ascii
-
-            npTicket.Platform = npTicket.TicketSignatureIdentifier switch
+            npTicket.Platform = npTicket.SignatureVerifier switch
             {
-                [0x52, 0x50, 0x43, 0x4E,] => Platform.RPCS3, // 'RPCN' in ascii
-                [0x54, 0x45, 0x53, 0x54,] => Platform.UnitTest, // 'TEST' in ascii
-                _ => npTicket.IssuerId switch
-                {
-                    0x100 => Platform.PS3,
-                    _ => Platform.Unknown,
-                }
+                PsnSignatureVerifier => Platform.PS3, 
+                RpcnSignatureVerifier => Platform.RPCS3,
+                UnitTestSignatureVerifier => Platform.UnitTest,
+                _ => Platform.Unknown,
             };
 
             if (npTicket.GameVersion == GameVersion.LittleBigPlanetVita) npTicket.Platform = Platform.Vita;

--- a/ProjectLighthouse/Tickets/NPTicket.cs
+++ b/ProjectLighthouse/Tickets/NPTicket.cs
@@ -160,13 +160,17 @@ public class NPTicket
             }
 
             // Production PSN Issuer ID: 0x100
-            // RPCN Issuer ID:           0x33333333
-            npTicket.Platform = npTicket.IssuerId switch
+            // The RPCN signature identifier is always 'RPCN' in ascii
+
+            npTicket.Platform = npTicket.TicketSignatureIdentifier switch
             {
-                0x100 => Platform.PS3,
-                0x33333333 => Platform.RPCS3,
-                0x74657374 => Platform.UnitTest,
-                _ => Platform.Unknown,
+                [0x52, 0x50, 0x43, 0x4E,] => Platform.RPCS3, // 'RPCN' in ascii
+                [0x54, 0x45, 0x53, 0x54,] => Platform.UnitTest, // 'TEST' in ascii
+                _ => npTicket.IssuerId switch
+                {
+                    0x100 => Platform.PS3,
+                    _ => Platform.Unknown,
+                }
             };
 
             if (npTicket.GameVersion == GameVersion.LittleBigPlanetVita) npTicket.Platform = Platform.Vita;

--- a/ProjectLighthouse/Tickets/NPTicket.cs
+++ b/ProjectLighthouse/Tickets/NPTicket.cs
@@ -155,7 +155,7 @@ public class NPTicket
 
             npTicket.Platform = npTicket.SignatureVerifier switch
             {
-                PsnSignatureVerifier => Platform.PS3, 
+                PsnSignatureVerifier => Platform.PS3,
                 RpcnSignatureVerifier => Platform.RPCS3,
                 UnitTestSignatureVerifier => Platform.UnitTest,
                 _ => Platform.Unknown,


### PR DESCRIPTION
RPCN is changing their ticket generator backend to use the same issuer ID as PSN meaning we can no longer use it to easily identify is a ticket is RPCN. Fortunately, the signature section of the ticket in RPCN is constant and we can just check that instead.