### PR TITLE
Add config options to restrict signup on certain platforms

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,7 +1,9 @@
 name: Qodana
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
   push:
     branches: # Specify your branches here
       - main # The 'main' branch
@@ -26,3 +28,6 @@ jobs:
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1488465344 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
@@ -130,6 +130,23 @@ public class LoginController : ControllerBase
                 Logger.Warn($"Unknown user tried to connect username={username}", LogArea.Login);
                 return this.Forbid();
             }
+
+            // Block RPCN signups if forbidden in config
+            if (npTicket.Platform == Platform.RPCS3 && !ServerConfiguration.Instance.Authentication.AllowRPCNSignup)
+            {
+                Logger.Warn(
+                    $"New user tried to sign up via RPCN, and that is forbidden in the config, username={username}, remoteIpAddress={remoteIpAddress}",
+                    LogArea.Login);
+            }
+
+            // Block PSN signups if forbidden in config
+            if (npTicket.Platform == Platform.RPCS3 && !ServerConfiguration.Instance.Authentication.AllowPSNSignup)
+            {
+                Logger.Warn(
+                    $"New user tried to sign up via PSN, and that is forbidden in the config, username={username}, remoteIpAddress={remoteIpAddress}",
+                    LogArea.Login);
+            }
+            
             // create account for user if they don't exist
             user = await this.database.CreateUser(username, "$");
             user.Password = null;

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
@@ -17,8 +17,14 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Login;
 [ApiController]
 [Route("LITTLEBIGPLANETPS3_XML/login")]
 [Produces("text/xml")]
-public class LoginController(DatabaseContext database) : ControllerBase
+public class LoginController : ControllerBase
 {
+    private readonly DatabaseContext database;
+    public LoginController(DatabaseContext database)
+    {
+        this.database = database;
+    }
+    
     [HttpPost]
     public async Task<IActionResult> Login()
     {
@@ -51,13 +57,13 @@ public class LoginController(DatabaseContext database) : ControllerBase
 
         string username = npTicket.Username;
 
-        if (String.IsNullOrEmpty(username))
+        if (string.IsNullOrEmpty(username))
         {
             Logger.Warn("Unable to determine username, rejecting login", LogArea.Login);
             return this.Forbid();
         }
 
-        await database.RemoveExpiredTokens();
+        await this.database.RemoveExpiredTokens();
 
         UserEntity? user;
 

--- a/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
+++ b/ProjectLighthouse.Servers.GameServer/Controllers/Login/LoginController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using LBPUnion.ProjectLighthouse.Configuration;
 using LBPUnion.ProjectLighthouse.Database;
@@ -18,15 +17,8 @@ namespace LBPUnion.ProjectLighthouse.Servers.GameServer.Controllers.Login;
 [ApiController]
 [Route("LITTLEBIGPLANETPS3_XML/login")]
 [Produces("text/xml")]
-public class LoginController : ControllerBase
+public class LoginController(DatabaseContext database) : ControllerBase
 {
-    private readonly DatabaseContext database;
-
-    public LoginController(DatabaseContext database)
-    {
-        this.database = database;
-    }
-
     [HttpPost]
     public async Task<IActionResult> Login()
     {
@@ -57,27 +49,27 @@ public class LoginController : ControllerBase
 
         string ipAddress = remoteIpAddress.ToString();
 
-        string? username = npTicket.Username;
+        string username = npTicket.Username;
 
-        if (username == null)
+        if (String.IsNullOrEmpty(username))
         {
             Logger.Warn("Unable to determine username, rejecting login", LogArea.Login);
             return this.Forbid();
         }
 
-        await this.database.RemoveExpiredTokens();
+        await database.RemoveExpiredTokens();
 
         UserEntity? user;
 
         switch (npTicket.Platform)
         {
             case Platform.RPCS3:
-                user = await this.database.Users.FirstOrDefaultAsync(u => u.LinkedRpcnId == npTicket.UserId);
+                user = await database.Users.FirstOrDefaultAsync(u => u.LinkedRpcnId == npTicket.UserId);
                 break;
             case Platform.PS3:
             case Platform.Vita:
             case Platform.UnitTest:
-                user = await this.database.Users.FirstOrDefaultAsync(u => u.LinkedPsnId == npTicket.UserId);
+                user = await database.Users.FirstOrDefaultAsync(u => u.LinkedPsnId == npTicket.UserId);
                 break;
             case Platform.PSP:
             case Platform.Unknown:
@@ -89,7 +81,7 @@ public class LoginController : ControllerBase
         if (user == null)
         {
             // Check if there is an account with that username already
-            UserEntity? targetUsername = await this.database.Users.FirstOrDefaultAsync(u => u.Username == npTicket.Username);
+            UserEntity? targetUsername = await database.Users.FirstOrDefaultAsync(u => u.Username == npTicket.Username);
             if (targetUsername != null)
             {
                 ulong targetPlatform = npTicket.Platform == Platform.RPCS3
@@ -104,7 +96,7 @@ public class LoginController : ControllerBase
                 }
 
                 // if there is already a pending link request don't create another
-                bool linkAttemptExists = await this.database.PlatformLinkAttempts.AnyAsync(p =>
+                bool linkAttemptExists = await database.PlatformLinkAttempts.AnyAsync(p =>
                     p.Platform == npTicket.Platform &&
                     p.PlatformId == npTicket.UserId &&
                     p.UserId == targetUsername.UserId);
@@ -119,8 +111,8 @@ public class LoginController : ControllerBase
                     Timestamp = TimeHelper.TimestampMillis,
                     PlatformId = npTicket.UserId,
                 };
-                this.database.PlatformLinkAttempts.Add(linkAttempt);
-                await this.database.SaveChangesAsync();
+                database.PlatformLinkAttempts.Add(linkAttempt);
+                await database.SaveChangesAsync();
                 Logger.Success($"User '{npTicket.Username}' tried to login but platform isn't linked, platform={npTicket.Platform}", LogArea.Login);
                 return this.Forbid();
             }
@@ -137,22 +129,24 @@ public class LoginController : ControllerBase
                 Logger.Warn(
                     $"New user tried to sign up via RPCN, and that is forbidden in the config, username={username}, remoteIpAddress={remoteIpAddress}",
                     LogArea.Login);
+                return this.Forbid();
             }
 
             // Block PSN signups if forbidden in config
-            if (npTicket.Platform == Platform.RPCS3 && !ServerConfiguration.Instance.Authentication.AllowPSNSignup)
+            if (npTicket.Platform.IsPSN() && !ServerConfiguration.Instance.Authentication.AllowPSNSignup)
             {
                 Logger.Warn(
                     $"New user tried to sign up via PSN, and that is forbidden in the config, username={username}, remoteIpAddress={remoteIpAddress}",
                     LogArea.Login);
+                return this.Forbid();
             }
             
             // create account for user if they don't exist
-            user = await this.database.CreateUser(username, "$");
+            user = await database.CreateUser(username, "$");
             user.Password = null;
             user.LinkedRpcnId = npTicket.Platform == Platform.RPCS3 ? npTicket.UserId : 0;
             user.LinkedPsnId = npTicket.Platform != Platform.RPCS3 ? npTicket.UserId : 0;
-            await this.database.SaveChangesAsync();
+            await database.SaveChangesAsync();
 
             if (DiscordConfiguration.Instance.DiscordIntegrationEnabled)
             {
@@ -172,7 +166,7 @@ public class LoginController : ControllerBase
         // automatically change username if it doesn't match
         else if (user.Username != npTicket.Username)
         {
-            bool usernameExists = await this.database.Users.AnyAsync(u => u.Username == npTicket.Username);
+            bool usernameExists = await database.Users.AnyAsync(u => u.Username == npTicket.Username);
             if (usernameExists)
             {
                 Logger.Warn($"{npTicket.Platform} user changed their name to a name that is already taken," +
@@ -181,17 +175,17 @@ public class LoginController : ControllerBase
             }
             Logger.Info($"User's username has changed, old='{user.Username}', new='{npTicket.Username}', platform={npTicket.Platform}", LogArea.Login);
             user.Username = username;
-            await this.database.PlatformLinkAttempts.RemoveWhere(p => p.UserId == user.UserId);
+            await database.PlatformLinkAttempts.RemoveWhere(p => p.UserId == user.UserId);
             // unlink other platforms because the names no longer match
             if (npTicket.Platform == Platform.RPCS3)
                 user.LinkedPsnId = 0;
             else
                 user.LinkedRpcnId = 0;
 
-            await this.database.SaveChangesAsync();
+            await database.SaveChangesAsync();
         }
 
-        GameTokenEntity? token = await this.database.GameTokens.Include(t => t.User)
+        GameTokenEntity? token = await database.GameTokens.Include(t => t.User)
             .FirstOrDefaultAsync(t => t.User.Username == npTicket.Username && t.TicketHash == npTicket.TicketHash);
 
         if (token != null)
@@ -200,7 +194,7 @@ public class LoginController : ControllerBase
             return this.Forbid();
         }
 
-        token = await this.database.AuthenticateUser(user, npTicket, ipAddress);
+        token = await database.AuthenticateUser(user, npTicket, ipAddress);
         if (token == null)
         {
             Logger.Warn($"Unable to find/generate a token for username {npTicket.Username}", LogArea.Login);
@@ -217,7 +211,7 @@ public class LoginController : ControllerBase
 
         user.LastLogin = TimeHelper.TimestampMillis;
 
-        await this.database.SaveChangesAsync();
+        await database.SaveChangesAsync();
 
         // Create a new room on LBP2/3/Vita
         if (token.GameVersion != GameVersion.LittleBigPlanet1) RoomHelper.CreateRoom(user.UserId, token.GameVersion, token.Platform);

--- a/ProjectLighthouse/Configuration/ConfigurationCategories/AuthenticationConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ConfigurationCategories/AuthenticationConfiguration.cs
@@ -5,4 +5,9 @@ public class AuthenticationConfiguration
     public bool RegistrationEnabled { get; set; } = true;
     public bool AutomaticAccountCreation { get; set; } = true;
     public bool VerifyTickets { get; set; } = true;
+
+    public bool AllowRPCNSignup { get; set; } = true;
+
+    public bool AllowPSNSignup { get; set; } = true;
+    
 }

--- a/ProjectLighthouse/Configuration/ServerConfiguration.cs
+++ b/ProjectLighthouse/Configuration/ServerConfiguration.cs
@@ -11,7 +11,7 @@ public class ServerConfiguration : ConfigurationBase<ServerConfiguration>
     // This is so Lighthouse can properly identify outdated configurations and update them with newer settings accordingly.
     // If you are modifying anything here, this value MUST be incremented.
     // Thanks for listening~
-    public override int ConfigVersion { get; set; } = 26;
+    public override int ConfigVersion { get; set; } = 27;
 
     public override string ConfigName { get; set; } = "lighthouse.yml";
     public string WebsiteListenUrl { get; set; } = "http://localhost:10060";

--- a/ProjectLighthouse/Types/Users/Platform.cs
+++ b/ProjectLighthouse/Types/Users/Platform.cs
@@ -1,5 +1,14 @@
 namespace LBPUnion.ProjectLighthouse.Types.Users;
 
+public static class PlatformExtensions
+{
+
+    public static bool IsPSN(this Platform platform)
+    {
+        return platform == Platform.PS3 || platform == Platform.PSP || platform == Platform.Vita;
+    }
+}
+
 public enum Platform
 {
     PS3 = 0,


### PR DESCRIPTION
Due to a recent increate in abuse of our platform, I have implemented an option to disallow initial signup from certain platforms. It defaults to allow all signup attempts but can be easily restricted in the config. Also fixes the Qodana warnings in LoginController.cs