### PR TITLE
Upgrade upload artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # Attempt to upload results even if test fails.
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: lighthouse-test-results-${{matrix.os.prettyName}}


### PR DESCRIPTION
GitHub is deprecating `upload-artifact@v3` on November 30, 2024 and after that date any workflow still using v3 will fail.