### PR TITLE
Handle long entitlements section in NPTicket 2.1 tickets

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
+      security-events: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
       checks: write
       security-events: write
+      actions: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
+++ b/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
@@ -32,9 +32,6 @@ public class TicketParser21 : ITicketParser
         SectionHeader entitlementsSection = this.reader.ReadSectionHeader(); // entitlements section
         this.reader.SkipBytes(entitlementsSection.Length);
 
-        this.reader.ReadTicketEmpty(); // padding
-        this.reader.ReadTicketEmpty();
-
         SectionHeader footer = this.reader.ReadSectionHeader(); // footer header
         if (footer.Type != SectionType.Footer)
         {

--- a/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
+++ b/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
@@ -32,6 +32,8 @@ public class TicketParser21 : ITicketParser
         SectionHeader entitlementsSection = this.reader.ReadSectionHeader(); // entitlements section
         this.reader.SkipBytes(entitlementsSection.Length);
 
+        this.reader.ReadTicketEmpty(); // padding
+
         SectionHeader footer = this.reader.ReadSectionHeader(); // footer header
         if (footer.Type != SectionType.Footer)
         {

--- a/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
+++ b/ProjectLighthouse/Tickets/Parser/TicketParser21.cs
@@ -29,6 +29,9 @@ public class TicketParser21 : ITicketParser
 
         this.reader.ReadTicketUInt32(); // status
 
+        SectionHeader entitlementsSection = this.reader.ReadSectionHeader(); // entitlements section
+        this.reader.SkipBytes(entitlementsSection.Length);
+
         this.reader.ReadTicketEmpty(); // padding
         this.reader.ReadTicketEmpty();
 


### PR DESCRIPTION
This PR correctly reads the section header of the "entitlements" section within the NPTicket so it can skip the right number of bytes, as in rare cases there is extra data in this section.