### PR TITLE
Make not translatable strings translatable

### DIFF
--- a/ProjectLighthouse.Localization/General.resx
+++ b/ProjectLighthouse.Localization/General.resx
@@ -63,4 +63,13 @@
     <data name="notifications" xml:space="preserve">
         <value>Notifications</value>
     </data>
+    <data name="comments" xml:space="preserve">
+        <value>Comments</value>
+    </data>
+    <data name="heart" xml:space="preserve">
+      <value>Heart</value>
+    </data>
+    <data name="unheart" xml:space="preserve">
+        <value>Unheart</value>
+    </data>
 </root>

--- a/ProjectLighthouse.Localization/Profile.resx
+++ b/ProjectLighthouse.Localization/Profile.resx
@@ -30,4 +30,58 @@
     <data name="profile_tag" xml:space="preserve">
         <value>Profile Tag</value>
     </data>
+    <data name="playlists" xml:space="preserve">
+        <value>Playlists</value>
+    </data>
+    <data name="hearted_levels" xml:space="preserve">
+        <value>Hearted Levels</value>
+    </data>
+    <data name="queued_levels" xml:space="preserve">
+        <value>Queued Levels</value>
+    </data>
+    <data name="profile_settings" xml:space="preserve">
+        <value>Profile Settings</value>
+    </data>
+    <data name="privacy_settings" xml:space="preserve">
+        <value>Privacy Settings</value>
+    </data>
+    <data name="block" xml:space="preserve">
+        <value>Block</value>
+    </data>
+    <data name="unblock" xml:space="preserve">
+        <value>Unblock</value>
+    </data>
+    <data name="user_banned" xml:space="preserve">
+        <value>This user is currently banned.</value>
+    </data>
+    <data name="ban_reason" xml:space="preserve">
+        <value>Reason:</value>
+    </data>
+    <data name="ban_reason_tos" xml:space="preserve">
+        <value>This user has been banned for violating the Terms of Service. Remember to follow the rules!</value>
+    </data>
+    <data name="privacy_hidden" xml:space="preserve">
+        <value>The user's privacy settings prevent you from viewing this page.</value>
+    </data>
+    <data name="comments_banned" xml:space="preserve">
+        <value>Comments are disabled because the user is banned.</value>
+    </data>
+    <data name="no_photos" xml:space="preserve">
+        <value>This user hasn't uploaded any photos</value>
+    </data>
+    <data name="no_levels" xml:space="preserve">
+        <value>This user hasn't published any levels</value>
+    </data>
+    <data name="no_hearted_levels" xml:space="preserve">
+        <value>You haven't hearted any levels</value>
+    </data>
+    <data name="hearted_levels_count" xml:space="preserve">
+        <value>You have hearted {0} levels</value>
+    </data>
+    <data name="no_queued_levels" xml:space="preserve">
+        <value>You haven't queued any levels</value>
+    </data>
+    <data name="queued_levels_count" xml:space="preserve">
+        <value>There are {0} levels in your queue</value>
+    </data>
 </root>

--- a/ProjectLighthouse.Localization/StringLists/GeneralStrings.cs
+++ b/ProjectLighthouse.Localization/StringLists/GeneralStrings.cs
@@ -17,6 +17,9 @@ public static class GeneralStrings
     public static readonly TranslatableString Soon = create("soon");
     public static readonly TranslatableString Announcements = create("announcements");
     public static readonly TranslatableString Notifications = create("notifications");
+    public static readonly TranslatableString Comments = create("comments");
+    public static readonly TranslatableString Heart = create("heart");
+    public static readonly TranslatableString Unheart = create("unheart");
 
     private static TranslatableString create(string key) => new(TranslationAreas.General, key);
 }

--- a/ProjectLighthouse.Localization/StringLists/ProfileStrings.cs
+++ b/ProjectLighthouse.Localization/StringLists/ProfileStrings.cs
@@ -6,6 +6,24 @@ public static class ProfileStrings
     public static readonly TranslatableString Biography = create("biography");
     public static readonly TranslatableString NoBiography = create("no_biography");
     public static readonly TranslatableString ProfileTag = create("profile_tag");
+    public static readonly TranslatableString Playlists = create("playlists");
+    public static readonly TranslatableString HeartedLevels = create("hearted_levels");
+    public static readonly TranslatableString QueuedLevels = create("queued_levels");
+    public static readonly TranslatableString ProfileSettings = create("profile_settings");
+    public static readonly TranslatableString PrivacySettings = create("privacy_settings");
+    public static readonly TranslatableString Block = create("block");
+    public static readonly TranslatableString Unblock = create("unblock");
+    public static readonly TranslatableString UserBanned = create("user_banned");
+    public static readonly TranslatableString BanReason = create("ban_reason");
+    public static readonly TranslatableString BanReasonTOS = create("ban_reason_tos");
+    public static readonly TranslatableString PrivacyHidden = create("privacy_hidden");
+    public static readonly TranslatableString CommentsBanned = create("comments_banned");
+    public static readonly TranslatableString NoPhotos = create("no_photos");
+    public static readonly TranslatableString NoLevels = create("no_levels");
+    public static readonly TranslatableString NoHeartedLevels = create("no_hearted_levels");
+    public static readonly TranslatableString HeartedLevelsCount = create("hearted_levels_count");
+    public static readonly TranslatableString NoQueuedLevels = create("no_queued_levels");
+    public static readonly TranslatableString QueuedLevelsCount = create("queued_levels_count");
 
     private static TranslatableString create(string key) => new(TranslationAreas.Profile, key);
 }

--- a/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
+++ b/ProjectLighthouse.Servers.Website/Pages/UserPage.cshtml
@@ -23,15 +23,15 @@
 @if (Model.ProfileUser.IsBanned)
 {
     <div class="ui inverted red segment">
-        <h3><i class="ban icon"></i> This user is currently banned.</h3>
+        <h3><i class="ban icon"></i>@Model.Translate(ProfileStrings.UserBanned)</h3>
         @if (Model.User != null && Model.User.IsModerator)
         {
-            <b>Reason:</b>
+            <b>@Model.Translate(ProfileStrings.BanReason)</b>
             <span>"@Model.ProfileUser.BannedReason"</span>
         }
         else
         {
-            <p>This user has been banned for violating the Terms of Service. Remember to follow the rules!</p>
+            <p>@Model.Translate(ProfileStrings.BanReasonTOS)</p>
         }
     </div>
 }
@@ -62,28 +62,28 @@
             {
                 <a class="ui red button" href="/user/@Model.ProfileUser.UserId/block">
                     <i class="user alternate slash icon"></i>
-                    <span>Block</span>
+                    <span>@Model.Translate(ProfileStrings.Block)</span>
                 </a>
             }
             else
             {
                 <a class="ui black button" href="/user/@Model.ProfileUser.UserId/unblock">
                     <i class="user alternate icon"></i>
-                    <span>Unblock</span>
+                    <span>@Model.Translate(ProfileStrings.Unblock)</span>
                 </a>
             }
             if (!Model.IsProfileUserHearted)
             {
                 <a class="ui pink button" href="/user/@Model.ProfileUser.UserId/heart">
                     <i class="heart icon"></i>
-                    <span>Heart</span>
+                    <span>@Model.Translate(GeneralStrings.Heart)</span>
                 </a>
             }
             else
             {
                 <a class="ui pink button" href="/user/@Model.ProfileUser.UserId/unheart">
                     <i class="heart broken icon"></i>
-                    <span>Unheart</span>
+                    <span>@Model.Translate(GeneralStrings.Unheart)</span>
                 </a>
             }
         }
@@ -91,14 +91,14 @@
         {
             <a class="ui blue button" href="/user/@Model.ProfileUser.UserId/privacy">
                 <i class="eye icon"></i>
-                <span>Privacy Settings</span>
+                <span>@Model.Translate(ProfileStrings.PrivacySettings)</span>
             </a>
         }
         @if (Model.ProfileUser == Model.User || (Model.User?.IsModerator ?? false))
         {
             <a class="ui blue button" href="/user/@Model.ProfileUser.UserId/settings">
                 <i class="cog icon"></i>
-                <span>Profile Settings</span>
+                <span>@Model.Translate(ProfileStrings.ProfileSettings)</span>
             </a>
         }
         @if (Model.ProfileUser == Model.User)
@@ -149,7 +149,7 @@
 {
     <div class="ui red segment">
         <p>
-            <i>The user's privacy settings prevent you from viewing this page.</i>
+            <i>@Model.Translate(ProfileStrings.PrivacyHidden)</i>
         </p>
     </div>
 }
@@ -163,7 +163,7 @@ else
         <div class="@outerDiv">
             <div class="@innerDiv">
                 <a class="item active lh-sidebar" target="lh-comments">
-                    Comments
+                    @Model.Translate(GeneralStrings.Comments)
                 </a>
                 <a class="item lh-sidebar" target="lh-photos">
                     @Model.Translate(BaseLayoutStrings.HeaderPhotos)
@@ -173,15 +173,15 @@ else
                     @Model.Translate(BaseLayoutStrings.HeaderSlots)
                 </a>
                 <a class="item lh-sidebar" target="lh-playlists">
-                    Playlists
+                    @Model.Translate(ProfileStrings.Playlists)
                 </a>
                 @if (Model.User == Model.ProfileUser)
                 {
                     <a class="item lh-sidebar" target="lh-hearted">
-                        Hearted Levels
+                        @Model.Translate(ProfileStrings.HeartedLevels)
                     </a>
                     <a class="item lh-sidebar" target="lh-queued">
-                        Queued Levels
+                        @Model.Translate(ProfileStrings.QueuedLevels)
                     </a>
                 }
             </div>
@@ -195,7 +195,7 @@ else
                 {
                     <div class="ui yellow segment" id="comments">
                         <p>
-                            <i>Comments are disabled because the user is banned.</i>
+                            <i>@Model.Translate(ProfileStrings.CommentsBanned)</i>
                         </p>
                     </div>
                 }
@@ -230,7 +230,7 @@ else
                     }
                     else
                     {
-                        <p>This user hasn't uploaded any photos</p>
+                        <p>@Model.Translate(ProfileStrings.NoPhotos)</p>
                     }
                 </div>
             </div>
@@ -239,7 +239,7 @@ else
                 {
                     <div class="ui red segment">
                         <p>
-                            <i>The user's privacy settings prevent you from viewing this page.</i>
+                            <i>@Model.Translate(ProfileStrings.PrivacyHidden).</i>
                         </p>
                     </div>
                 }
@@ -248,7 +248,7 @@ else
                     <div class="ui green segment" id="levels">
                         @if (Model.Slots?.Count == 0)
                         {
-                            <p>This user hasn't published any levels</p>
+                            <p>@Model.Translate(ProfileStrings.NoLevels)</p>
                         }
                         @foreach (SlotEntity slot in Model.Slots ?? new List<SlotEntity>())
                         {
@@ -270,11 +270,11 @@ else
                     <div class="ui pink segment" id="hearted">
                         @if (Model.HeartedSlots?.Count == 0)
                         {
-                            <p>You haven't hearted any levels</p>
+                            <p>@Model.Translate(ProfileStrings.NoHeartedLevels)</p>
                         }
                         else
                         {
-                            <p>You have hearted @(Model.HeartedSlots?.Count) levels</p>
+                            <p>@Model.Translate(ProfileStrings.HeartedLevelsCount, Model.HeartedSlots?.Count)</p>
                         }
                         @foreach (SlotEntity slot in Model.HeartedSlots ?? new List<SlotEntity>())
                         {
@@ -288,11 +288,11 @@ else
                     <div class="ui yellow segment" id="queued">
                         @if (Model.QueuedSlots?.Count == 0)
                         {
-                            <p>You haven't queued any levels</p>
+                            <p>@Model.Translate(ProfileStrings.NoQueuedLevels)</p>
                         }
                         else
                         {
-                            <p>There are @(Model.QueuedSlots?.Count) levels in your queue</p>
+                            <p>@Model.Translate(ProfileStrings.QueuedLevelsCount, Model.QueuedSlots?.Count)</p>
                         }
                         @foreach (SlotEntity slot in Model.QueuedSlots ?? new List<SlotEntity>())
                         {


### PR DESCRIPTION
For some reason some of the strings on the website are not translatable, this pull request is aimed at resolving that issue